### PR TITLE
45 install user space apps without error if none is found

### DIFF
--- a/usr/build.sh
+++ b/usr/build.sh
@@ -105,7 +105,7 @@ mkdir -p build/deploy/
 # SO3 shell
 install_directory_root usr/out
 
-#install_file_elf
+install_file_elf
 
 
 

--- a/usr/build.sh
+++ b/usr/build.sh
@@ -11,8 +11,8 @@ function usage {
 
 function install_file_elf {
   if [ -f $1 ] ; then 
-    echo "Installing $1"  && mv build/src/*.elf build/deploy  
-    for subfolder_app in $(find build/src -type f -iwholename "**/*.elf"); do
+    echo "Installing $1" 
+    for subfolder_app in $(find build/src -type f -iname "*.elf"); do
       mv "$subfolder_app" build/deploy
     done
   fi
@@ -105,7 +105,7 @@ mkdir -p build/deploy/
 # SO3 shell
 install_directory_root usr/out
 
-install_file_elf
+#install_file_elf
 
 
 

--- a/usr/build.sh
+++ b/usr/build.sh
@@ -10,7 +10,12 @@ function usage {
 }
 
 function install_file_elf {
-  [ -f $1 ] && echo "Installing $1" && mv build/src/*.elf build/deploy && mv build/src/**/*.elf build/deploy
+  if [ -f $1 ] ; then 
+    echo "Installing $1"  && mv build/src/*.elf build/deploy  
+    for subfolder_app in $(find build/src -type f -iwholename "**/*.elf"); do
+      mv "$subfolder_app" build/deploy
+    done
+  fi
 }
 
 function install_file_root {


### PR DESCRIPTION
Installation of user-space apps (apps built in *build/src* or any of its subfolder) now uses a find+for-loop to install all apps and not throw any error when no app is found. This prevents errors being thrown when no subfolder app is built and anticipates a day when all apps may be subfolder apps