### PR TITLE
make st_mtim time_t for compatibility with libc

### DIFF
--- a/so3/include/stat.h
+++ b/so3/include/stat.h
@@ -29,7 +29,7 @@ typedef uint32_t mode_t;
 struct stat {
 	char	st_name[FILENAME_SIZE];		/* Filename */
 	unsigned long	st_size; 		/* Size of file */
-	unsigned long	st_mtim;		/* Time of last modification in sec*/
+	time_t	st_mtim;			/* Time of last modification in sec*/
 	unsigned char	st_flags;		/* Regular file flag (not supported on fat) */
 	mode_t	st_mode;			/* Protection not used (not supported on fat) */
 };


### PR DESCRIPTION
st_mtim is now a time_t so it stays 64 bits even when building in 32 bits mode