### PR TITLE
ci: add build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-virt32:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Build 
+        run: |
+          docker run --rm -v "${PWD}:/so3" ghcr.io/andrecostaaa/so3-env:main bash -c "cd so3 && make virt32_defconfig && make -j"
+
+  build-virt64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Build
+        run: |
+          docker run --rm -v "${PWD}:/so3" ghcr.io/andrecostaaa/so3-env:main bash -c "cd so3 && make virt64_defconfig && make -j"

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ agency/rootfs/target/**
 
 # except the followings:
 !.gitignore #Don't ignore the ignore file ;-)
+!.github 
 !*.tmpl #TaMPLate files for the man documentation
 !buildroot/**
 !buildroot/docs/manual/*.mk


### PR DESCRIPTION
Currently, the main branch of so3 can't be built using the `virt32_defconfig` config.

This PR is aimed at making sure so3 doesn't get broken again by adding a ci workflow that builds using virt32 and virt64 default configs. The PR that fixes it will get created soon

Other configurations may be easily added but i'm not aware what configs are actually meant to be used.

In order to achieve this i created a docker image containing everything needed to build so3 [here](https://github.com/AndreCostaaa/so3-env/). This makes sure we don't have to be constantly installing missing dependencies and is a good way for other people to know what are the project dependencies

Having this container, we can easily mount the current so3 project inside the container and run make

Let me know what you think