### PR TITLE
fix: don't include semihosting.h if config is arm32

### DIFF
--- a/so3/kernel/process.c
+++ b/so3/kernel/process.c
@@ -43,7 +43,9 @@
 #include <asm/mmu.h>
 #include <asm/process.h>
 #include <asm/processor.h>
+#ifndef CONFIG_ARCH_ARM32
 #include <asm/semihosting.h>
+#endif
 
 static char *proc_state_strings[5] = {
     [PROC_STATE_NEW] = "NEW",         [PROC_STATE_READY] = "READY",


### PR DESCRIPTION
Like I mentioned in #71 , virt32_defconfig is broken and can't currently be built. This PR fixes that