### PR TITLE
feat: so3 docker env

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   build-image:
     # Only run if the push hits main
-    if: endsWith(github.ref, 'main') == false
+    if: endsWith(github.ref, 'main') == true
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,7 @@ jobs:
         # In case we want to build other images we can add them here
         include:
           - dockerfile: ./docker/Dockerfile.env
-            image: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}-env
+            image: ghcr.io/${{ env.REPOSITORY }}-env
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,58 @@
+name: Docker Image CI
+
+on:
+  push:
+    paths:
+      - docker/Dockerfile.env
+
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+
+jobs:
+  build-image:
+    # Only run if the push hits main
+    if: endsWith(github.ref, 'main') == false
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # In case we want to build other images we can add them here
+        include:
+          - dockerfile: ./docker/Dockerfile.env
+            image: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}-env
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ matrix.image }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,7 +7,6 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  REPOSITORY: ${{ github.repository }}
 
 jobs:
   build-image:
@@ -20,7 +19,7 @@ jobs:
         # In case we want to build other images we can add them here
         include:
           - dockerfile: ./docker/Dockerfile.env
-            image: ghcr.io/${{ env.REPOSITORY }}-env
+            image: ghcr.io/smartobjectoriented/so3/so3-env
     permissions:
       contents: read
       packages: write

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ agency/rootfs/target/**
 
 # except the followings:
 !.gitignore #Don't ignore the ignore file ;-)
+!.github
 !*.tmpl #TaMPLate files for the man documentation
 !buildroot/**
 !buildroot/docs/manual/*.mk

--- a/docker/Dockerfile.env
+++ b/docker/Dockerfile.env
@@ -27,18 +27,14 @@ RUN rm gcc-arm-10.3-2021.07-x86_64-aarch64-none-linux-gnu.tar.xz
 ENV PATH="$PATH:/gcc-arm-10.3-2021.07-x86_64-aarch64-none-linux-gnu/bin"
 
 
+# Get current so3 so we can build qemu
 RUN wget https://github.com/smartobjectoriented/so3/archive/refs/heads/main.zip
-
 RUN unzip main.zip
 RUN rm main.zip
-RUN mv so3-* so3
-
-
-RUN cd /so3/qemu && ls -la && ./fetch.sh &&  ./configure --target-list=arm-softmmu,aarch64-softmmu --disable-attr --disable-werror --disable-docs
-RUN mv /so3/qemu /qemu
-
-ENV PATH="$PATH:/qemu/build"
-
-RUN rm -rf /so3
+RUN mv so3-* generated
+RUN cd /generated/qemu && ./fetch.sh &&  ./configure --target-list=arm-softmmu,aarch64-softmmu --disable-attr --disable-werror --disable-docs
+ENV PATH="$PATH:/generated/qemu/build"
+# Remove everything except qemu
+RUN cd /generated && rm -rf !(qemu)
 
 WORKDIR so3

--- a/docker/Dockerfile.env
+++ b/docker/Dockerfile.env
@@ -1,0 +1,44 @@
+FROM ubuntu:22.04 
+
+RUN dpkg --add-architecture i386
+RUN apt update
+RUN apt install libc6:i386 libncurses5:i386 libstdc++6:i386 -y
+RUN apt install lib32z1-dev -y
+RUN apt install zlib1g:i386 -y
+RUN apt install pkg-config libgtk2.0-dev bridge-utils -y
+RUN apt install unzip bc -y
+RUN apt install elfutils u-boot-tools -y
+RUN apt install device-tree-compiler -y
+RUN apt install fdisk -y
+RUN apt install libncurses-dev -y
+RUN apt install flex bison -y
+
+RUN apt install gcc-arm-none-eabi -y
+RUN apt install wget unzip -y
+RUN apt install python3-venv -y
+RUN apt install ninja-build -y
+RUN apt install git -y
+
+# Download aarch64-none-linux-gnu toolchain
+RUN wget https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-a/10.3-2021.07/binrel/gcc-arm-10.3-2021.07-x86_64-aarch64-none-linux-gnu.tar.xz
+RUN tar -xvf gcc-arm-10.3-2021.07-x86_64-aarch64-none-linux-gnu.tar.xz
+RUN rm gcc-arm-10.3-2021.07-x86_64-aarch64-none-linux-gnu.tar.xz
+
+ENV PATH="$PATH:/gcc-arm-10.3-2021.07-x86_64-aarch64-none-linux-gnu/bin"
+
+
+RUN wget https://github.com/smartobjectoriented/so3/archive/refs/heads/main.zip
+
+RUN unzip main.zip
+RUN rm main.zip
+RUN mv so3-* so3
+
+
+RUN cd /so3/qemu && ls -la && ./fetch.sh &&  ./configure --target-list=arm-softmmu,aarch64-softmmu --disable-attr --disable-werror --disable-docs
+RUN mv /so3/qemu /qemu
+
+ENV PATH="$PATH:/qemu/build"
+
+RUN rm -rf /so3
+
+WORKDIR so3

--- a/docker/Dockerfile.env
+++ b/docker/Dockerfile.env
@@ -35,6 +35,6 @@ RUN mv so3-* generated
 RUN cd /generated/qemu && ./fetch.sh &&  ./configure --target-list=arm-softmmu,aarch64-softmmu --disable-attr --disable-werror --disable-docs
 ENV PATH="$PATH:/generated/qemu/build"
 # Remove everything except qemu
-RUN cd /generated && rm -rf !(qemu)
+RUN find /generated -mindepth 1 -maxdepth 1 -not -name "qemu" -exec rm -rf {} +
 
 WORKDIR so3

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,7 @@
+# so3-docker
+
+This repository contains Dockerfiles related to so3.
+
+## [Dockerfile.env](./Dockerfile.env)
+
+An ubuntu based image with necessary prerequisites to build and run so3.


### PR DESCRIPTION
As discussed in #71, this PR adds
- Dockerfile.env with an ubuntu based image with all prerequisites to build and run so3
- docker.yml, a workflow to build so3 related docker image**s**. For now it only builds the so3-env image but it can easily be extended

I also created a `docker` directory to put every dockerfile like discussed here https://github.com/smartobjectoriented/so3/pull/71#discussion_r1856513791. For now i've only put the Dockerfile.env there as i believe moving the other dockerfiles is outside the scope of this PR