### PR TITLE
fix docker so3-env package name

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,7 +19,7 @@ jobs:
         # In case we want to build other images we can add them here
         include:
           - dockerfile: ./docker/Dockerfile.env
-            image: ghcr.io/smartobjectoriented/so3/so3-env
+            image: ghcr.io/smartobjectoriented/so3-env
     permissions:
       contents: read
       packages: write

--- a/docker/Dockerfile.env
+++ b/docker/Dockerfile.env
@@ -26,7 +26,6 @@ RUN rm gcc-arm-10.3-2021.07-x86_64-aarch64-none-linux-gnu.tar.xz
 
 ENV PATH="$PATH:/gcc-arm-10.3-2021.07-x86_64-aarch64-none-linux-gnu/bin"
 
-
 # Get current so3 so we can build qemu
 RUN wget https://github.com/smartobjectoriented/so3/archive/refs/heads/main.zip
 RUN unzip main.zip


### PR DESCRIPTION
I made a small mistake in #73 by naming the so3-env package `ghcr.io/smarobjectoriented/so3/so3-env`
The ci passed but there's no way to find the new image.

The package can't be found in github: https://github.com/orgs/smartobjectoriented/packages?repo_name=so3

And the repository page is buggy with github showing there's 1 package but no extra info:

![image](https://github.com/user-attachments/assets/d4789acb-b068-4b6b-bbc2-a4ae8b708009)

We should expect something like this: 
![image](https://github.com/user-attachments/assets/17f6c761-fac0-4385-8e6e-90db20d4952c)

Trying to pull the image also fails:

```bash
docker pull ghcr.io/smartobjectoriented/so3/so3-env
Using default tag: latest
Error response from daemon: denied
```

Also while writing this PR the job just showed up as [failed](https://github.com/AndreCostaaa/so3/actions/runs/12054402360/job/33612343214) even though it had previously showed up as succeeded. Go figure...

This PR fixes this by removing the extra `/so3` from the image name renaming it from `ghcr.io/smartojectoriented/so3/so3-env` to `ghcr.io/smartojectoriented/so3-env`
