### PR TITLE
fix: command dont get executed when arrow key pressed

### DIFF
--- a/usr/src/sh.c
+++ b/usr/src/sh.c
@@ -50,9 +50,11 @@ void parse_token(char *str) {
 		strcpy(tokens[i++], next_token);
 }
 
+/**
+ * Remove 0 before command
+ */
 void trim(char* buffer, int n){
 	int i;
-
 	char* new_buff = calloc(80, sizeof(char));
 	for(i = 0; i < n; i++){
 		if(buffer[i] != 0){
@@ -64,10 +66,17 @@ void trim(char* buffer, int n){
 	free(new_buff);
 }
 
+
+/**
+ * Detect if its a escape sequence
+ */
 int is_escape_sequence(const char* str) {
     return str[0] == '\x1b' && str[1] == '[';
 }
 
+/**
+ * Escape arrow key sequence to avoid interpret them
+ */
 void escape_arrow_key(char* buffer, int size){
 	int i,j;
 	char* new_buff = calloc(size, sizeof(char));
@@ -83,7 +92,10 @@ void escape_arrow_key(char* buffer, int size){
 	free(new_buff);
 }
 
-char* get_user_input(char* buffer, int buf_size) {
+/**
+ * More secure way and escaped way to get user input
+ */
+void get_user_input(char* buffer, int buf_size) {
     if (buffer == NULL || buf_size <= 0) {
         return NULL;
     }


### PR DESCRIPTION
This PR addresses an issue in the SO3 shell where the input command is not executed properly after pressing an arrow key. The issue arises because the shell incorrectly interprets escape sequences generated by arrow key presses, causing subsequent commands to be ignored.

To resolve this, the PR introduces a mechanism to detect any escape sequences in the user input, such as those generated by arrow keys, and properly handle or remove them before executing the command. This ensures that the input is correctly parsed, and commands are executed as expected.

Additionally, this change improves the overall safety of user input by ensuring that any escape sequences or unwanted characters are sanitized before further processing.

I am open to any feedback or suggestions regarding this implementation !