### PR TITLE
fix(fdt): correctly memset device struct object

### DIFF
--- a/so3/devices/fdt.c
+++ b/so3/devices/fdt.c
@@ -47,7 +47,7 @@ static void init_dev_info(dev_t *dev) {
 
 	/* Clear out whole structure */
 
-	memset(dev, 0, sizeof(dev));
+	memset(dev, 0, sizeof(*dev));
 
 	dev->status = STATUS_UNKNOWN;
 	dev->offset_dts = -1;


### PR DESCRIPTION
While clearing out a dev_t structure, the incorrect argument is passed to `sizeof` making it so we don't actually clear out the whole struct object but only the first 4/8 bytes depending on architecture