### PR TITLE
fix support for VA of 39 bits

### DIFF
--- a/so3/arch/arm64/mmu.c
+++ b/so3/arch/arm64/mmu.c
@@ -339,10 +339,6 @@ void __create_mapping(void *pgtable, addr_t virt_base, addr_t phys_base, size_t 
 	mmu_page_table_flush((addr_t) pgtable, (addr_t) (pgtable + TTB_L0_SIZE));
 }
 
-void create_mapping(void *pgtable, addr_t virt_base, addr_t phys_base, size_t size, bool nocache) {
-	__create_mapping(pgtable, virt_base, phys_base, size, nocache, S1);
-}
-
 #elif CONFIG_VA_BITS_39
 
 /**
@@ -355,7 +351,7 @@ void create_mapping(void *pgtable, addr_t virt_base, addr_t phys_base, size_t si
  * @param size
  * @param nocache	true for I/O access typically
  */
-void create_mapping(void *l1pgtable, addr_t virt_base, addr_t phys_base, size_t size, bool nocache) {
+static void __create_mapping(void *l1pgtable, addr_t virt_base, addr_t phys_base, size_t size, bool nocache, mmu_stage_t stage) {
 	addr_t addr, end, length, next, phys;
 	u64 *l1pte;
 
@@ -380,6 +376,10 @@ void create_mapping(void *l1pgtable, addr_t virt_base, addr_t phys_base, size_t 
 
 			set_pte_block(l1pte, (nocache ? DCACHE_OFF : DCACHE_WRITEALLOC));
 
+			/* Set AP[1] bit 6 to 1 to make R/W/Executable the pages in user space */
+			if ((addr != phys) && user_space_vaddr(addr))
+				*l1pte |= PTE_BLOCK_AP1;
+
 			DBG("Allocating a 1 GB block at l1pte: %p content: %lx\n", l1pte, *l1pte);
 
 			flush_pte_entry(addr, l1pte);
@@ -388,7 +388,7 @@ void create_mapping(void *l1pgtable, addr_t virt_base, addr_t phys_base, size_t 
 			addr += SZ_1G;
 
 		} else {
-			alloc_init_l2(l1pgtable, addr, next, phys, nocache);
+			alloc_init_l2(l1pgtable, addr, next, phys, nocache, stage);
 			phys += next - addr;
 			addr = next;
 		}
@@ -401,6 +401,10 @@ void create_mapping(void *l1pgtable, addr_t virt_base, addr_t phys_base, size_t 
 #else
 #error "Wrong VA_BITS configuration."
 #endif
+
+void create_mapping(void *pgtable, addr_t virt_base, addr_t phys_base, size_t size, bool nocache) {
+	__create_mapping(pgtable, virt_base, phys_base, size, nocache, S1);
+}
 
 static bool empty_table(void *pgtable) {
 	int i;
@@ -416,7 +420,10 @@ static bool empty_table(void *pgtable) {
 }
 
 void release_mapping(void *pgtable, addr_t vaddr, size_t size) {
-	uint64_t *l0pte, *l1pte, *l2pte, *l3pte;
+#ifdef CONFIG_VA_BITS_48
+	uint64_t *l0pte;
+#endif
+	uint64_t *l1pte, *l2pte, *l3pte;
 	size_t free_size = 0;
 
 	/* If l1pgtable is NULL, we consider the system page table */
@@ -427,12 +434,21 @@ void release_mapping(void *pgtable, addr_t vaddr, size_t size) {
 	size = ALIGN_UP(size + (vaddr & ~PAGE_MASK), PAGE_SIZE);
 
 	while (free_size < size) {
+#ifdef CONFIG_VA_BITS_48
 		l0pte = l0pte_offset(pgtable, vaddr);
 		if (!*l0pte)
 			/* Already free */
 			return ;
 
 		l1pte = l1pte_offset(l0pte, vaddr);
+#elif CONFIG_VA_BITS_39
+		l1pte = l1pte_offset(pgtable, vaddr);
+		if (!*l1pte)
+			/* Already free */
+			return ;
+#else
+#error "Wrong VA_BITS configuration."
+#endif
 		BUG_ON(!*l1pte);
 
 		if (pte_type(l1pte) == PTE_TYPE_BLOCK) {
@@ -442,8 +458,10 @@ void release_mapping(void *pgtable, addr_t vaddr, size_t size) {
 			free_size += BLOCK_1G_OFFSET;
 			vaddr += BLOCK_1G_OFFSET;
 
+#ifdef CONFIG_VA_BITS_48
 			if (empty_table(l0pte))
 				free(l0pte);
+#endif
 		} else {
 			BUG_ON(pte_type(l1pte) != PTE_TYPE_TABLE);
 			l2pte = l2pte_offset(l1pte, vaddr);
@@ -518,6 +536,58 @@ void copy_root_pgtable(void *dst, void *src) {
 }
 
 /**
+ * Reset a page table so that it has no child associated with it.
+ * We do not consider any shared pages/page tables.
+ *
+ * @param pgtable Page table of any level to reset.
+ * @param level   Level of the page table.
+ */
+static void __reset_pgtable(u64 *pgtable, int level)
+{
+	int i;
+	u64 *pte;
+	u64 *child_pgtable;
+	size_t entries, table_addr_mask;
+
+	switch (level) {
+	case 2:
+		entries = TTB_L2_ENTRIES;
+		table_addr_mask = TTB_L2_TABLE_ADDR_MASK;
+		break;
+	case 1:
+		entries = TTB_L1_ENTRIES;
+		table_addr_mask = TTB_L1_TABLE_ADDR_MASK;
+		break;
+	case 0:
+		entries = TTB_L0_ENTRIES;
+		table_addr_mask = TTB_L0_TABLE_ADDR_MASK;
+		break;
+
+	default:
+		BUG();
+		break;
+	}
+
+
+	for (i = 0; i < entries; i++) {
+		pte = pgtable + i;
+
+		if (*pte && (pte_type(pte) == PTE_TYPE_TABLE)) {
+			child_pgtable = (u64 *) __va(*pte & table_addr_mask);
+
+			if (level < 2) {
+				__reset_pgtable(child_pgtable, level + 1);
+			}
+
+			free(child_pgtable);
+			*pte = 0;
+		}
+	}
+
+	mmu_page_table_flush((addr_t) pgtable, (addr_t) (pgtable + entries));
+}
+
+/**
  * Free a root page table and its associated Lx page tables used for the user space area.
  * We do not consider any shared pages/page tables.
  *
@@ -525,51 +595,17 @@ void copy_root_pgtable(void *dst, void *src) {
  * @param remove  true if we keep the root page table for subsequent allocations
  */
 void reset_root_pgtable(void *pgtable, bool remove) {
-	int i;
-	u64 *pgtable_l1, *pgtable_l2, *pgtable_l3;
-	u64 *l0pte, *l1pte, *l2pte;
 
-	for (i = 0; i < TTB_L0_ENTRIES; i++) {
-
-		l0pte = (u64 *) pgtable + i;
-
-		/* Check if a L2 page table is used */
-		if (*l0pte) {
-			pgtable_l1 = (u64 *) __va(*l0pte & TTB_L0_TABLE_ADDR_MASK);
-
-			for (i = 0; i < TTB_L1_ENTRIES; i++) {
-
-				l1pte = pgtable_l1 + i;
-
-				if (*l1pte && (pte_type(l1pte) == PTE_TYPE_TABLE)) {
-					pgtable_l2 = (u64 *) __va(*l1pte & TTB_L1_TABLE_ADDR_MASK);
-
-					for (i = 0; i < TTB_L2_ENTRIES; i++) {
-						l2pte = pgtable_l2 + i;
-
-						if (*l2pte && (pte_type(l2pte) == PTE_TYPE_TABLE)) {
-							pgtable_l3 = (u64 *) __va(*l2pte & TTB_L2_TABLE_ADDR_MASK);
-
-							free(pgtable_l3);
-							*l2pte = 0;
-						}
-					}
-
-					free(pgtable_l2);
-					*l1pte = 0;
-				}
-			}
-
-			free(pgtable_l1);
-			*l0pte = 0;
-		}
-	}
+#ifdef CONFIG_VA_BITS_48
+	__reset_pgtable((u64 *)pgtable, 0);
+#elif CONFIG_VA_BITS_39
+	__reset_pgtable((u64 *)pgtable, 1);
+#else
+#error "Wrong VA_BITS configuration."
+#endif
 
 	if (remove)
 		free(pgtable);
-
-	mmu_page_table_flush((addr_t) pgtable, (addr_t) (pgtable + TTB_L1_ENTRIES));
-
 }
 
 /*
@@ -628,8 +664,17 @@ void mmu_configure(addr_t fdt_addr) {
 			set_pte_block(&__sys_linearmap_l2pgtable[l2pte_index(CONFIG_KERNEL_VADDR + i*SZ_2M)], DCACHE_WRITEALLOC);
 		}
 #elif CONFIG_VA_BITS_39
-		__sys_root_pgtable[l1pte_index(CONFIG_KERNEL_VADDR)] = mem_info.phys_base & TTB_L1_BLOCK_ADDR_MASK;
-		set_pte_block(&__sys_root_pgtable[l1pte_index(CONFIG_KERNEL_VADDR)], DCACHE_WRITEALLOC);
+		__sys_root_pgtable[l1pte_index(CONFIG_KERNEL_VADDR)] = (u64) __sys_linearmap_l2pgtable & TTB_L1_TABLE_ADDR_MASK;
+		set_pte_table(&__sys_root_pgtable[l1pte_index(CONFIG_KERNEL_VADDR)], DCACHE_WRITEALLOC);
+
+		/* Set up a 128 MB linear mapping to progress with the bootstrap code
+		 * until the memory manager re-configure the memory mapping with
+		 * a better granularity.
+		 */
+		for (i = 0; i < 64; i++) {
+			__sys_linearmap_l2pgtable[l2pte_index(CONFIG_KERNEL_VADDR + i*SZ_2M)] = (mem_info.phys_base + i*SZ_2M) & TTB_L2_BLOCK_ADDR_MASK;
+			set_pte_block(&__sys_linearmap_l2pgtable[l2pte_index(CONFIG_KERNEL_VADDR + i*SZ_2M)], DCACHE_WRITEALLOC);
+		}
 #else
 #error "Wrong VA_BITS configuration."
 #endif
@@ -639,7 +684,7 @@ void mmu_configure(addr_t fdt_addr) {
 		__sys_idmap_l1pgtable[l1pte_index(CONFIG_UART_LL_PADDR)] = CONFIG_UART_LL_PADDR & TTB_L1_BLOCK_ADDR_MASK;
 		set_pte_block(&__sys_idmap_l1pgtable[l1pte_index(CONFIG_UART_LL_PADDR)], DCACHE_OFF);
 #elif CONFIG_VA_BITS_39
-		__sys_root_pgtable[l1pte_index(UART_BASE)] = CONFIG_UART_LL_PADDR & TTB_L1_BLOCK_ADDR_MASK;
+		__sys_root_pgtable[l1pte_index(CONFIG_UART_LL_PADDR)] = CONFIG_UART_LL_PADDR & TTB_L1_BLOCK_ADDR_MASK;
 		set_pte_block(&__sys_root_pgtable[l1pte_index(CONFIG_UART_LL_PADDR)], DCACHE_OFF);
 #else
 #error "Wrong VA_BITS configuration."
@@ -865,8 +910,13 @@ void duplicate_pgtable_entry(u64 *from, u64 *to, int level, u64 vaddr, pcb_t *pc
 void duplicate_user_space(pcb_t *from, pcb_t *to) {
 
 	/* Walk through the L0 pgtable and copy the entries */
-
+#ifdef CONFIG_VA_BITS_48
 	duplicate_pgtable_entry((u64 *) from->pgtable, (u64 *) to->pgtable, 0, 0, to);
+#elif CONFIG_VA_BITS_39
+	duplicate_pgtable_entry((u64 *) from->pgtable, (u64 *) to->pgtable, 1, 0, to);
+#else
+#error "Wrong VA_BITS configuration."
+#endif
 }
 
 #ifdef CONFIG_RAMDEV
@@ -892,11 +942,15 @@ void ramdev_create_mapping(void *root_pgtable, addr_t ramdev_start, addr_t ramde
  * @return	physical addr corresponding to vaddr
  */
 addr_t virt_to_phys_pt(addr_t vaddr) {
-	addr_t *l0pte, *l1pte, *l2pte, *l3pte;
+#ifdef CONFIG_VA_BITS_48
+	addr_t *l0pte;
+#endif
+	addr_t *l1pte, *l2pte, *l3pte;
 	uint32_t offset;
 
 	offset = vaddr & ~PAGE_MASK;
 
+#ifdef CONFIG_VA_BITS_48
 	if (user_space_vaddr(vaddr))
 		l0pte = l0pte_offset(current_pgtable(), vaddr);
 	else
@@ -906,6 +960,15 @@ addr_t virt_to_phys_pt(addr_t vaddr) {
 
 	l1pte = l1pte_offset(l0pte, vaddr);
 	BUG_ON(!*l1pte);
+#elif CONFIG_VA_BITS_39
+	if (user_space_vaddr(vaddr))
+		l1pte = l1pte_offset((u64*)current_pgtable(), vaddr);
+	else
+		l1pte = l1pte_offset(__sys_root_pgtable, vaddr);
+	BUG_ON(!*l1pte);
+#else
+#error "Wrong VA_BITS configuration."
+#endif
 
 	if (pte_type(l1pte) == PTE_TYPE_BLOCK)
 		return (*l1pte & TTB_L1_BLOCK_ADDR_MASK) | offset;

--- a/so3/configs/rpi4_64_39b_va_defconfig
+++ b/so3/configs/rpi4_64_39b_va_defconfig
@@ -1,0 +1,78 @@
+#
+# Automatically generated make config: don't edit
+# SO3 Polymorphic OS Configuration
+#
+# CONFIG_ARCH_ARM32 is not set
+CONFIG_ARCH_ARM64=y
+# CONFIG_SO3VIRT is not set
+CONFIG_ARCH="arm64"
+CONFIG_CROSS_COMPILE="aarch64-none-linux-gnu-"
+# CONFIG_ARM_TRUSTZONE is not set
+CONFIG_KERNEL_VADDR=0xffffffc000000000
+
+#
+# Platform
+#
+# CONFIG_VIRT64 is not set
+CONFIG_RPI4_64=y
+CONFIG_VA_BITS_39=y
+# CONFIG_VA_BITS_48 is not set
+# CONFIG_THREAD_ENV is not set
+CONFIG_PROC_ENV=y
+
+#
+# Kernel & CPU features
+#
+# CONFIG_SMP is not set
+CONFIG_NR_CPUS=1
+CONFIG_HZ=100
+CONFIG_SCHED_FLIP_SCHEDFREQ=30
+
+#
+# SO3 Scheduling configuration
+#
+CONFIG_SCHED_RR=y
+# CONFIG_SCHED_PRIO is not set
+CONFIG_SCHED_FREQ_PREEMPTION=y
+
+#
+# Drivers
+#
+CONFIG_UART=y
+CONFIG_IO_MAPPING_BASE=0xffffffc800000000
+# CONFIG_I2C is not set
+# CONFIG_NET is not set
+# CONFIG_FB is not set
+# CONFIG_INPUT is not set
+# CONFIG_NS16550 is not set
+CONFIG_BCM283x_MU_UART=y
+CONFIG_UART_LL_PADDR=0xfe215040
+# CONFIG_MMC is not set
+CONFIG_RAMDEV=y
+CONFIG_ARM_TIMER=y
+CONFIG_GIC=y
+
+#
+# SO3 Applications
+#
+# CONFIG_APP_SAMPLE is not set
+
+#
+# Filesystems
+#
+CONFIG_FS_FAT=y
+# CONFIG_ROOTFS_NONE is not set
+# CONFIG_ROOTFS_MMC is not set
+CONFIG_ROOTFS_RAMDEV=y
+
+#
+# IPC
+#
+CONFIG_IPC_SIGNAL=y
+CONFIG_IPC_PIPE=y
+CONFIG_HEAP_SIZE=8
+# CONFIG_RTOS is not set
+# CONFIG_AVZ is not set
+# CONFIG_SOO is not set
+CONFIG_MMU=y
+CONFIG_DEBUG_PRINTK=y

--- a/so3/configs/virt64_39b_va_defconfig
+++ b/so3/configs/virt64_39b_va_defconfig
@@ -1,0 +1,81 @@
+#
+# Automatically generated make config: don't edit
+# SO3 Polymorphic OS Configuration
+#
+# CONFIG_ARCH_ARM32 is not set
+CONFIG_ARCH_ARM64=y
+# CONFIG_SO3VIRT is not set
+CONFIG_ARCH="arm64"
+CONFIG_CROSS_COMPILE="aarch64-none-linux-gnu-"
+# CONFIG_ARM_TRUSTZONE is not set
+CONFIG_KERNEL_VADDR=0xffffffc000000000
+
+#
+# Platform
+#
+CONFIG_VIRT64=y
+# CONFIG_RPI4_64 is not set
+CONFIG_VA_BITS_39=y
+# CONFIG_VA_BITS_48 is not set
+# CONFIG_THREAD_ENV is not set
+CONFIG_PROC_ENV=y
+
+#
+# Kernel & CPU features
+#
+# CONFIG_SMP is not set
+CONFIG_NR_CPUS=1
+CONFIG_HZ=100
+CONFIG_SCHED_FLIP_SCHEDFREQ=30
+
+#
+# SO3 Scheduling configuration
+#
+CONFIG_SCHED_RR=y
+# CONFIG_SCHED_PRIO is not set
+CONFIG_SCHED_FREQ_PREEMPTION=y
+
+#
+# Drivers
+#
+CONFIG_UART=y
+CONFIG_IO_MAPPING_BASE=0xffffffc800000000
+# CONFIG_I2C is not set
+# CONFIG_NET is not set
+# CONFIG_FB is not set
+# CONFIG_INPUT is not set
+# CONFIG_NS16550 is not set
+CONFIG_PL011_UART=y
+CONFIG_UART_LL_PADDR=0x09000000
+# CONFIG_MMC is not set
+CONFIG_RAMDEV=y
+CONFIG_ARM_TIMER=y
+CONFIG_GIC=y
+# CONFIG_PL111_CLCD is not set
+# CONFIG_QEMU_RAMFB is not set
+# CONFIG_PL050_KMI is not set
+
+#
+# SO3 Applications
+#
+CONFIG_APP_SAMPLE=y
+
+#
+# Filesystems
+#
+CONFIG_FS_FAT=y
+# CONFIG_ROOTFS_NONE is not set
+# CONFIG_ROOTFS_MMC is not set
+CONFIG_ROOTFS_RAMDEV=y
+
+#
+# IPC
+#
+CONFIG_IPC_SIGNAL=y
+CONFIG_IPC_PIPE=y
+CONFIG_HEAP_SIZE=8
+# CONFIG_RTOS is not set
+# CONFIG_AVZ is not set
+# CONFIG_SOO is not set
+CONFIG_MMU=y
+# CONFIG_DEBUG_PRINTK is not set


### PR DESCRIPTION
This PR fix the support for virtual address of 39 bits as it wasn't even compiling. I tested that fix on virt64 and RPI4 and provided the two workings configs.

Closes #81 