### PR TITLE
Refactor syscall abi to allow up to 6 arguments on ARM64

### DIFF
--- a/so3/arch/arm32/context.S
+++ b/so3/arch/arm32/context.S
@@ -37,7 +37,6 @@
 
 .globl __get_syscall_args_ext
 .globl __get_syscall_arg
-.globl __get_syscall_stack_arg
 
 .global __mmu_switch_ttbr0
 .global __exec
@@ -63,29 +62,6 @@ __enable_vfp:
     mov r1, #0x40000000
     vmsr fpexc, r1 ; fpexc = r1
     bx lr
-
-@ Get the arguments of the syscall which are stored on the stack
-@ (greather than 4 args (r0-r3))
-@ r0 contains the number of args (0 = first argument on the stack,
-@ hence the fifth argument of the syscall, 1 = second arg. on the stack,
-@ hence the sixth arg., etc.
-@ Returns the value in r0 (according to the EABI)
-__get_syscall_stack_arg:
-
-	ldr	r1, .LCcurrent
-	ldr r1, [r1]
-
-	@ Get the user stack pointer at the entry of the interrupt vector
-	ldr	r1, [r1, #(OFFSET_TCB_CPU_REGS + OFFSET_SP_USR)]
-
-	@ The syscall stub uses r7, r10 and r11. These are NO scratch register
-	@ and are preserved on the stack before the exception.
-	@ Therefore, we have to skip 12 bytes.
-	add r1, r1, #12
-
-	ldr r0, [r1, r0, lsl #2]
-
-	mov pc, lr
 
 @ Get the additional arguments linked to the syscall.
 @ The ABI convention is described in crt0.S of the libc.

--- a/so3/arch/arm32/exception.S
+++ b/so3/arch/arm32/exception.S
@@ -292,9 +292,11 @@ syscall_interrupt:
 	ldmfd 	sp!, {r0-r4}
 #endif
 
-	cpsie   i 			@ Re-enable interrupts
-    bl 		syscall_handle
-    cpsid	i			@ Re-disable interrupts to be safe in regs manipulation
+	mov	r0, sp
+
+	cpsie	i 			@ Re-enable interrupts
+	bl	syscall_handle
+	cpsid	i			@ Re-disable interrupts to be safe in regs manipulation
 
 	@ Check if sigreturn has been called. In this case, we
 	@ clean the stack frame which has been used to manage the user handler.

--- a/so3/arch/arm64/context.S
+++ b/so3/arch/arm64/context.S
@@ -33,7 +33,6 @@
 
 .globl __get_syscall_args_ext
 .globl __get_syscall_arg
-.globl __get_syscall_stack_arg
 
 .global __mmu_switch
 .global __exec
@@ -171,32 +170,6 @@ ENTRY(cpu_do_idle)
 	dsb	  sy			// WFI may enter a low-power mode
 	wfi
 
-	ret
-
-// Get the arguments of the syscall which are stored on the stack
-// (greather than 4 args (r0-r3))
-// r0 contains the number of args (0 = first argument on the stack,
-// hence the fifth argument of the syscall, 1 = second arg. on the stack,
-// hence the sixth arg., etc.
-// Returns the value in r0 (according to the EABI)
-__get_syscall_stack_arg:
-
-#if 0
-	ldr	r1, .LCcurrent
-	ldr r1, [r1]
-
-	// Get the user stack pointer at the entry of the interrupt vector
-	ldr	r1, [r1, #(OFFSET_TCB_CPU_REGS + OFFSET_SP_USR)]
-
-	// The syscall stub uses r7, r10 and r11. These are NO scratch register
-	// and are preserved on the stack before the exception.
-	// Therefore, we have to skip 12 bytes.
-	add r1, r1, #12
-
-	ldr r0, [r1, r0, lsl #2]
-
-	mov pc, lr
-#endif
 	ret
 
 // Get the additional arguments linked to the syscall.

--- a/so3/arch/arm64/traps.c
+++ b/so3/arch/arm64/traps.c
@@ -123,6 +123,10 @@ extern addr_t cpu_entrypoint;
 typedef void(*vector_fn_t)(cpu_regs_t *);
 
 int trap_handle(cpu_regs_t *regs) {
+#ifndef CONFIG_AVZ
+	syscall_args_t sys_args;
+#endif
+
 #ifdef CONFIG_ARM64VT
 	unsigned long esr = read_sysreg(esr_el2);
 	unsigned long hvc_code;
@@ -152,8 +156,15 @@ int trap_handle(cpu_regs_t *regs) {
 
 #else /* CONFIG_AVZ */
 
+		sys_args.args[0] = regs->x0;
+		sys_args.args[1] = regs->x1;
+		sys_args.args[2] = regs->x2;
+		sys_args.args[3] = regs->x3;
+		sys_args.args[4] = regs->x4;
+		sys_args.args[5] = regs->x5;
+
 		local_irq_enable();
-		regs->x0 = syscall_handle(regs->x0, regs->x1, regs->x2, regs->x3);
+		regs->x0 = syscall_handle(&sys_args);
 		local_irq_disable();
 #endif /* !CONFIG_AVZ */
 

--- a/so3/include/syscall.h
+++ b/so3/include/syscall.h
@@ -91,7 +91,11 @@
 #include <errno.h>
 #include <types.h>
 
-long syscall_handle(unsigned long, unsigned long, unsigned long, unsigned long);
+typedef struct {
+	unsigned long args[6];
+} syscall_args_t;
+
+long syscall_handle(syscall_args_t *);
 
 void set_errno(uint32_t val);
 #endif /* __ASSEMBLY__ */

--- a/so3/include/types.h
+++ b/so3/include/types.h
@@ -55,7 +55,7 @@
 typedef unsigned long size_t;
 typedef int ssize_t;
 
-typedef signed int ptrdiff_t;
+typedef signed long ptrdiff_t;
 
 typedef unsigned int wchar_t;
 

--- a/so3/kernel/syscalls.c
+++ b/so3/kernel/syscalls.c
@@ -58,12 +58,11 @@ void set_errno(uint32_t val) {
 }
 
 /*
- * Process syscalls according to the syscall number passed in r7.
- * According to the ARM EABI, arguments are passed into registers r0-r3,
- * and then on the (user) stack.
+ * Process syscalls according to the syscall number passed in r7 on ARM and x8 on ARM64.
+ * According to SO3 ABI, the syscall arguments are passed in r0-r5 on ARM and x0-x5 on ARM64.
  */
 
-long syscall_handle(unsigned long r0, unsigned long r1, unsigned long r2, unsigned long r3)
+long syscall_handle(syscall_args_t *a)
 {
 	long result = -1;
 	uint32_t syscall_no, *__errno_addr;
@@ -81,15 +80,15 @@ long syscall_handle(unsigned long r0, unsigned long r1, unsigned long r2, unsign
 			break;
 
 		case SYSCALL_GETTIMEOFDAY:
-			/* r1 contains a pointer to the timezone structure. */
+			/* a->args[1] contains a pointer to the timezone structure. */
 			/* Currently, this is not supported yet. */
 
-			result = do_get_time_of_day((struct timespec *) r0);
+			result = do_get_time_of_day((struct timespec *) a->args[0]);
 			break;
 
 		case SYSCALL_CLOCK_GETTIME:
 
-			result = do_get_clock_time(r0, (struct timespec *) r1);
+			result = do_get_clock_time(a->args[0], (struct timespec *) a->args[1]);
 			break;
 
 		case SYSCALL_SETTIMEOFDAY:
@@ -101,11 +100,11 @@ long syscall_handle(unsigned long r0, unsigned long r1, unsigned long r2, unsign
 			break;
 
 		case SYSCALL_EXIT:
-			do_exit(r0);
+			do_exit(a->args[0]);
 			break;
 
 		case SYSCALL_EXECVE:
-			result = do_execve((const char *) r0, (char **) r1, (char **) r2);
+			result = do_execve((const char *) a->args[0], (char **) a->args[1], (char **) a->args[2]);
 			break;
 
 		case SYSCALL_FORK:
@@ -113,37 +112,37 @@ long syscall_handle(unsigned long r0, unsigned long r1, unsigned long r2, unsign
 			break;
 
 		case SYSCALL_WAITPID:
-			result = do_waitpid(r0, (uint32_t *) r1, r2);
+			result = do_waitpid(a->args[0], (uint32_t *) a->args[1], a->args[2]);
 			break;
 #endif /* CONFIG_MMU */
 
 		case SYSCALL_READ:
-			result = do_read(r0, (void *) r1, r2);
+			result = do_read(a->args[0], (void *) a->args[1], a->args[2]);
 			break;
 
 		case SYSCALL_WRITE:
-			result = do_write(r0, (void *) r1, r2);
+			result = do_write(a->args[0], (void *) a->args[1], a->args[2]);
 			break;
 
 		case SYSCALL_OPEN:
-			result = do_open((const char *) r0, r1);
+			result = do_open((const char *) a->args[0], a->args[1]);
 			break;
 
 		case SYSCALL_CLOSE:
-			do_close((int) r0);
+			do_close((int) a->args[0]);
 			result = 0;
 			break;
 
 		case SYSCALL_THREAD_CREATE:
-			result = do_thread_create((uint32_t *) r0, r1, r2, r3);
+			result = do_thread_create((uint32_t *) a->args[0], a->args[1], a->args[2], a->args[3]);
 			break;
 
 		case SYSCALL_THREAD_JOIN:
-			result = do_thread_join(r0, (int **) r1);
+			result = do_thread_join(a->args[0], (int **) a->args[1]);
 			break;
 
 		case SYSCALL_THREAD_EXIT:
-			do_thread_exit((int *) r0);
+			do_thread_exit((int *) a->args[0]);
 			result = 0;
 			break;
 
@@ -153,50 +152,50 @@ long syscall_handle(unsigned long r0, unsigned long r1, unsigned long r2, unsign
 			break;
 
 		case SYSCALL_READDIR:
-			result = do_readdir((int) r0, (char *) r1, r2);
+			result = do_readdir((int) a->args[0], (char *) a->args[1], a->args[2]);
 			break;
 
 		case SYSCALL_IOCTL:
-			result = do_ioctl((int) r0, (unsigned long) r1, (unsigned long) r2);
+			result = do_ioctl((int) a->args[0], (unsigned long) a->args[1], (unsigned long) a->args[2]);
 			break;
 
 		case SYSCALL_FCNTL:
-			result = do_fcntl((int) r0, (int) r1, (unsigned long) r2);
+			result = do_fcntl((int) a->args[0], (int) a->args[1], (unsigned long) a->args[2]);
 			break;
 
 		case SYSCALL_LSEEK:
-			result = do_lseek((int) r0, (off_t) r1, (int) r2);
+			result = do_lseek((int) a->args[0], (off_t) a->args[1], (int) a->args[2]);
 			break;
 
 #ifdef CONFIG_IPC_PIPE
 		case SYSCALL_PIPE:
-			result = do_pipe((int *) r0);
+			result = do_pipe((int *) a->args[0]);
 			break;
 #endif /* CONFIG_IPC_PIPE */
 
 		case SYSCALL_DUP:
-			result = do_dup((int) r0);
+			result = do_dup((int) a->args[0]);
 			break;
 
 		case SYSCALL_DUP2:
-			result = do_dup2((int) r0, (int) r1);
+			result = do_dup2((int) a->args[0], (int) a->args[1]);
 			break;
 
 		case SYSCALL_STAT:
-			result = do_stat((char *) r0, (struct stat *) r1);
+			result = do_stat((char *) a->args[0], (struct stat *) a->args[1]);
 			break;
 
 		case SYSCALL_MMAP:
-			result = (long) do_mmap((addr_t) r0, (size_t) r1, (int) r2, (int) r3, (off_t) __get_syscall_stack_arg(0));
+			result = (long) do_mmap((addr_t) a->args[0], (size_t) a->args[1], (int) a->args[2], (int) a->args[3], (off_t) a->args[4]);
 			break;
 
 		case SYSCALL_NANOSLEEP:
-			result = do_nanosleep((const struct timespec *) r0, (struct timespec *) r1);
+			result = do_nanosleep((const struct timespec *) a->args[0], (struct timespec *) a->args[1]);
 			break;
 
 #ifdef CONFIG_PROC_ENV
 		case SYSCALL_SBRK:
-			result = do_sbrk((unsigned long) r0);
+			result = do_sbrk((unsigned long) a->args[0]);
 			break;
 
 #endif /* CONFIG_PROC_ENV */
@@ -205,26 +204,26 @@ long syscall_handle(unsigned long r0, unsigned long r1, unsigned long r2, unsign
 	 * Mainly used for debugging purposes (kernel mutex validation) at the moment ... */
 
 		case SYSCALL_MUTEX_LOCK:
-			result = do_mutex_lock(&current()->pcb->lock[r0]);
+			result = do_mutex_lock(&current()->pcb->lock[a->args[0]]);
 			break;
 
 		case SYSCALL_MUTEX_UNLOCK:
-			result = do_mutex_unlock(&current()->pcb->lock[r0]);
+			result = do_mutex_unlock(&current()->pcb->lock[a->args[0]]);
 			break;
 
 #ifdef CONFIG_MMU
 		case SYSCALL_PTRACE:
-			result = do_ptrace((enum __ptrace_request) r0, (uint32_t) r1, (void *) r2, (void *) r3);
+			result = do_ptrace((enum __ptrace_request) a->args[0], (uint32_t) a->args[1], (void *) a->args[2], (void *) a->args[3]);
 			break;
 #endif
 
 #ifdef CONFIG_IPC_SIGNAL
 		case SYSCALL_SIGACTION:
-			result = do_sigaction((int) r0, (sigaction_t *) r1, (sigaction_t *) r2);
+			result = do_sigaction((int) a->args[0], (sigaction_t *) a->args[1], (sigaction_t *) a->args[2]);
 			break;
 
 		case SYSCALL_KILL:
-			result = do_kill((int) r0, (int) r1);
+			result = do_kill((int) a->args[0], (int) a->args[1]);
 			break;
 
 		case SYSCALL_SIGRETURN:
@@ -235,53 +234,53 @@ long syscall_handle(unsigned long r0, unsigned long r1, unsigned long r2, unsign
 
 #ifdef CONFIG_NET
 		case SYSCALL_SOCKET:
-			result = do_socket((int)r0, (int)r1, (int)r2);
+			result = do_socket((int)a->args[0], (int)a->args[1], (int)a->args[2]);
 			break;
 
 		case SYSCALL_BIND:
-			result = do_bind((int) r0, (const struct sockaddr *) r1, (socklen_t) r2);
+			result = do_bind((int) a->args[0], (const struct sockaddr *) a->args[1], (socklen_t) a->args[2]);
 			break;
 
 		case SYSCALL_LISTEN:
-			result = do_listen((int)r0, (int) r1);
+			result = do_listen((int)a->args[0], (int) a->args[1]);
 			break;
 
 		case SYSCALL_ACCEPT:
-			result = do_accept((int) r0, (struct sockaddr *) r1, (socklen_t *) r2);
+			result = do_accept((int) a->args[0], (struct sockaddr *) a->args[1], (socklen_t *) a->args[2]);
 			break;
 
 		case SYSCALL_CONNECT:
-			result = do_connect((int) r0, (const struct sockaddr *) r1, (socklen_t) r2);
+			result = do_connect((int) a->args[0], (const struct sockaddr *) a->args[1], (socklen_t) a->args[2]);
 			break;
 
 		case SYSCALL_RECV:
-			result = do_recv((int)r0, (void*) r1, (size_t) r2, (int) r3);
+			result = do_recv((int)a->args[0], (void*) a->args[1], (size_t) a->args[2], (int) a->args[3]);
 			break;
 
 		case SYSCALL_SEND:
-			result = do_send((int)r0, (const void *) r1, (size_t) r2, (int) r3);
+			result = do_send((int)a->args[0], (const void *) a->args[1], (size_t) a->args[2], (int) a->args[3]);
 			break;
 
 		case SYSCALL_SENDTO:
-			result = do_sendto((int)r0, (const void *)r1, (size_t)r2, (int)r3,
-					(const struct sockaddr *) __get_syscall_stack_arg(0),
-					(socklen_t) __get_syscall_stack_arg(1));
+			result = do_sendto((int)a->args[0], (const void *)a->args[1], (size_t)a->args[2], (int)a->args[3],
+					(const struct sockaddr *) a->args[4],
+					(socklen_t) a->args[5]);
 			break;
 
 		case SYSCALL_SETSOCKOPT:
-			result = do_setsockopt((int) r0, (int) r1, (int) r2, (const void *) r3, (socklen_t) __get_syscall_stack_arg(0));
+			result = do_setsockopt((int) a->args[0], (int) a->args[1], (int) a->args[2], (const void *) a->args[3], (socklen_t) a->args[4]);
 			break;
 
 		case SYSCALL_RECVFROM:
-			result = do_recvfrom((int) r0, (void *) r1, (size_t) r2, (int) r3, (struct sockaddr *) __get_syscall_stack_arg(0),
-					(socklen_t *)__get_syscall_stack_arg(1));
+			result = do_recvfrom((int) a->args[0], (void *) a->args[1], (size_t) a->args[2], (int) a->args[3], (struct sockaddr *) a->args[4],
+					(socklen_t *)a->args[5]);
 			break;
 
 #endif /* CONFIG_NET */
 
 		/* Sysinfo syscalls */
 		case SYSCALL_SYSINFO:
-			switch (r0) {
+			switch (a->args[0]) {
 			case SYSINFO_DUMP_HEAP:
 				dump_heap("Heap info asked from user.\n");
 				break;
@@ -298,11 +297,11 @@ long syscall_handle(unsigned long r0, unsigned long r1, unsigned long r2, unsign
 
 #ifdef CONFIG_APP_TEST_MALLOC
 			case SYSINFO_TEST_MALLOC:
-				test_malloc(r1);
+				test_malloc(a->args[1]);
 				break;
 #endif
 			case SYSINFO_PRINTK:
-				printk("%s", (char *) r1);
+				printk("%s", (char *) a->args[1]);
 				break;
 			}
 			result = 0;

--- a/usr/lib/libc/crt0.S
+++ b/usr/lib/libc/crt0.S
@@ -48,20 +48,29 @@ __start:
 
 	nop
 
+#ifdef __ARM__
+
 /* -------------------------------------------------------------
  * System call stubs:
  * - r0-r3 are used to store arguments
+ * - Further argument are on stack and will be put to r4-r5 if needed.
  * - r7 is used to store the syscall number
  * -------------------------------------------------------------
  */
 
-#ifdef __ARM__
-
-.macro SYSCALLSTUB name, number
+.macro SYSCALLSTUB name, number, nargs
 	.globl	\name
 \name:
 
-  stmfd sp!, {r7, r10, ip}
+  stmfd sp!, {r4, r5, r7, r10, ip}
+
+/* Retrieve arguments 5 and 6 from the stack if needed */
+.ifge	\nargs - 5
+  ldr	r4, [sp, #20]
+.endif
+.ifge	\nargs - 6
+  ldr	r5, [sp, #24]
+.endif
 
   mov	r7, #\number
 
@@ -71,7 +80,7 @@ __start:
 
   swi	0
 
-  ldmfd sp!, {r7, r10, ip}
+  ldmfd sp!, {r4, r5, r7, r10, ip}
 
   mov pc, lr
 
@@ -79,7 +88,14 @@ __start:
 
 #else /* __ARM64__ */
 
-.macro SYSCALLSTUB name, number
+/* -------------------------------------------------------------
+ * System call stubs:
+ * - x0-x5 are used to store arguments
+ * - x8 is used to store the syscall number
+ * -------------------------------------------------------------
+ */
+
+.macro SYSCALLSTUB name, number, nargs
 	.globl	\name
 \name:
 
@@ -97,7 +113,7 @@ __start:
 
   svc	0
 
-  ldr 	x8, [sp]
+  ldr	x8, [sp]
   ldr	x9, [sp, #8]
   ldr	lr, [sp, #16]
 
@@ -112,62 +128,62 @@ __start:
 
 
 /* Syscalls stubs */
-SYSCALLSTUB sys_halt, 			syscallHalt
-SYSCALLSTUB sys_write,			syscallWrite
-SYSCALLSTUB sys_read, 			syscallRead
-SYSCALLSTUB sys_exit, 			syscallExit
-SYSCALLSTUB sys_execve,			syscallExecve
-SYSCALLSTUB sys_waitpid,		syscallWaitpid
-SYSCALLSTUB sys_pause, 			syscallPause
-SYSCALLSTUB sys_fork, 			syscallFork
-SYSCALLSTUB sys_readdir, 		syscallReaddir
-SYSCALLSTUB sys_chdir, 			syscallChdir
-SYSCALLSTUB sys_getcwd, 		syscallGetcwd
-SYSCALLSTUB sys_creat, 			syscallCreate
-SYSCALLSTUB sys_unlink, 		syscallUnlink
-SYSCALLSTUB sys_open, 			syscallOpen
-SYSCALLSTUB sys_close, 			syscallClose
-SYSCALLSTUB sys_thread_create, 	syscallThreadCreate
-SYSCALLSTUB sys_thread_join, 	syscallThreadJoin
-SYSCALLSTUB sys_thread_exit, 	syscallThreadExit
-SYSCALLSTUB sys_thread_yield,   syscallThreadYield
-SYSCALLSTUB sys_pipe, 			syscallPipe
-SYSCALLSTUB sys_ioctl,			syscallIoctl
-SYSCALLSTUB sys_fcntl,	 	    syscallFcntl
-SYSCALLSTUB sys_stat,	 		syscallStat
-SYSCALLSTUB sys_dup,	 		syscallDup
-SYSCALLSTUB sys_dup2,	 		syscallDup2
-SYSCALLSTUB sys_sched_setparam, syscallSchedSetParam
-SYSCALLSTUB sys_socket, 		syscallSocket
-SYSCALLSTUB sys_bind, 			syscallBind
-SYSCALLSTUB sys_listen, 		syscallListen
-SYSCALLSTUB sys_accept, 		syscallAccept
-SYSCALLSTUB sys_connect, 		syscallConnect
-SYSCALLSTUB sys_mmap, 			syscallMmap
-SYSCALLSTUB sys_ptrace,  		syscallPtrace
-SYSCALLSTUB sys_send,	 		syscallSend
-SYSCALLSTUB sys_recv, 			syscallRecv
-SYSCALLSTUB sys_recvfrom, 		syscallRecvfrom
-SYSCALLSTUB sys_setsockopt, 	syscallSetsockopt
-SYSCALLSTUB sys_sendto, 		syscallSendTo
-SYSCALLSTUB sys_getpid,			syscallGetpid
+SYSCALLSTUB sys_halt,			syscallHalt		0
+SYSCALLSTUB sys_write,			syscallWrite		3
+SYSCALLSTUB sys_read,			syscallRead		3
+SYSCALLSTUB sys_exit,			syscallExit		1
+SYSCALLSTUB sys_execve,			syscallExecve		3
+SYSCALLSTUB sys_waitpid,		syscallWaitpid		3
+SYSCALLSTUB sys_pause,			syscallPause		1
+SYSCALLSTUB sys_fork,			syscallFork		0
+SYSCALLSTUB sys_readdir,		syscallReaddir		3
+/* SYSCALLSTUB sys_chdir,			syscallChdir  */
+/* SYSCALLSTUB sys_getcwd,			syscallGetcwd */
+SYSCALLSTUB sys_creat,			syscallCreate		2
+SYSCALLSTUB sys_unlink,			syscallUnlink		1
+SYSCALLSTUB sys_open,			syscallOpen		3
+SYSCALLSTUB sys_close,			syscallClose		1
+SYSCALLSTUB sys_thread_create,		syscallThreadCreate	4
+SYSCALLSTUB sys_thread_join,		syscallThreadJoin	2
+SYSCALLSTUB sys_thread_exit,		syscallThreadExit	1
+SYSCALLSTUB sys_thread_yield,		syscallThreadYield	0
+SYSCALLSTUB sys_pipe,			syscallPipe		1
+SYSCALLSTUB sys_ioctl,			syscallIoctl		3
+SYSCALLSTUB sys_fcntl,			syscallFcntl		3
+SYSCALLSTUB sys_stat,			syscallStat		2
+SYSCALLSTUB sys_dup,			syscallDup		1
+SYSCALLSTUB sys_dup2,			syscallDup2		2
+SYSCALLSTUB sys_sched_setparam,		syscallSchedSetParam	2
+SYSCALLSTUB sys_socket,			syscallSocket		3
+SYSCALLSTUB sys_bind,			syscallBind		3
+SYSCALLSTUB sys_listen,			syscallListen		2
+SYSCALLSTUB sys_accept,			syscallAccept		3
+SYSCALLSTUB sys_connect,		syscallConnect		3
+SYSCALLSTUB sys_mmap,			syscallMmap		5
+SYSCALLSTUB sys_ptrace,			syscallPtrace		4
+SYSCALLSTUB sys_send,			syscallSend		4
+SYSCALLSTUB sys_recv,			syscallRecv		4
+SYSCALLSTUB sys_recvfrom,		syscallRecvfrom		6
+SYSCALLSTUB sys_setsockopt,		syscallSetsockopt	5
+SYSCALLSTUB sys_sendto,			syscallSendTo		6
+SYSCALLSTUB sys_getpid,			syscallGetpid		0
 
-SYSCALLSTUB sys_gettimeofday,	syscallGetTimeOfDay
-SYSCALLSTUB sys_settimeofday,	syscallSetTimeOfDay
-SYSCALLSTUB sys_clock_gettime,  syscallClockGetTime
+SYSCALLSTUB sys_gettimeofday,		syscallGetTimeOfDay	2
+SYSCALLSTUB sys_settimeofday,		syscallSetTimeOfDay	2
+SYSCALLSTUB sys_clock_gettime,		syscallClockGetTime	2
 
-SYSCALLSTUB sys_sbrk,			syscallSbrk
-SYSCALLSTUB sys_info,	    	syscallSysinfo
+SYSCALLSTUB sys_sbrk,			syscallSbrk		1
+SYSCALLSTUB sys_info,			syscallSysinfo		2
 
-SYSCALLSTUB sys_lseek,			syscallLseek
+SYSCALLSTUB sys_lseek,			syscallLseek		3
 
-SYSCALLSTUB sys_mutex_lock,	    syscallMutexLock
-SYSCALLSTUB sys_mutex_unlock,	syscallMutexUnlock
+SYSCALLSTUB sys_mutex_lock,		syscallMutexLock	1
+SYSCALLSTUB sys_mutex_unlock,		syscallMutexUnlock	1
 
-SYSCALLSTUB sys_sigaction,		syscallSigaction
-SYSCALLSTUB sys_kill,			syscallKill
-SYSCALLSTUB sys_sigreturn,		syscallSigreturn
+SYSCALLSTUB sys_sigaction,		syscallSigaction	3
+SYSCALLSTUB sys_kill,			syscallKill		2
+SYSCALLSTUB sys_sigreturn,		syscallSigreturn	0
 
-SYSCALLSTUB sys_nanosleep,		syscallNanosleep
+SYSCALLSTUB sys_nanosleep,		syscallNanosleep	2
 
 


### PR DESCRIPTION
This pull request refactor the syscall abi by passing every arguments in registers (`r0-r5` for ARM32 and `x0-x5` for ARM64) instead of using the stack. It has disadvantage to limit the number of arguments to 6, but this behavior is the one used in Linux (`man syscall` to get more details) which will allows more compatibility with it. If more arguments are required, structure can always be used.

On the user side, the assembly macro `SYSCALLSTUB` is modified to copy the arguments passed on stack (by the function calling ABI) into register if needed. It could be interesting to reuse the original musl libc syscall macro which automatically detect the number of arguments and put them correctly into the registers reducing the ammount of needed code modification on the musl libc. This would require more work through.