### PR TITLE
fix: fail to build usr

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Build 
         run: |
-          docker run --rm -v "${PWD}:/so3" ghcr.io/smartobjectoriented/so3-env:main bash -c "cd so3 && make virt32_defconfig && make -j"
+          docker run --rm -v "${PWD}:/so3" ghcr.io/smartobjectoriented/so3-env:main bash -c "cd so3 && make virt32_defconfig && make -j`nproc`"
 
   build-virt64:
     runs-on: ubuntu-latest
@@ -27,7 +27,7 @@ jobs:
 
       - name: Build
         run: |
-          docker run --rm -v "${PWD}:/so3" ghcr.io/smartobjectoriented/so3-env:main bash -c "cd so3 && make virt64_defconfig && make -j"
+          docker run --rm -v "${PWD}:/so3" ghcr.io/smartobjectoriented/so3-env:main bash -c "cd so3 && make virt64_defconfig && make -j`nproc`"
 
   build-usr:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,10 +31,18 @@ jobs:
 
   build-usr:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        CMAKE_TOOLCHAIN_FILE: ['../aarch64_toolchain.cmake', 
+                               '../arm_toolchain.cmake']
+        BUILD_TYPE: ["Debug", "Release"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
 
       - name: Build
         run: |
-          docker run --rm -t -v "${PWD}:/so3" ghcr.io/smartobjectoriented/so3-env:main bash -c "cd usr && ./build.sh"
+          docker run --rm -t -v "${PWD}:/so3" ghcr.io/smartobjectoriented/so3-env:main bash -c "
+          mkdir usr/build && cd usr/build && cmake -Wall -Werror -Wno-dev --no-warn-unused-cli -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }} -DCMAKE_TOOLCHAIN_FILE= ${{matrix.CMAKE_TOOLCHAIN_FILE } .. &&
+          make -j{nproc}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,4 @@ jobs:
 
       - name: Build
         run: |
-          docker run --rm -t -v "${PWD}:/so3" ghcr.io/smartobjectoriented/so3-env:main bash -c "
-          mkdir usr/build && cd usr/build && cmake -Wall -Werror -Wno-dev --no-warn-unused-cli -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }} -DCMAKE_TOOLCHAIN_FILE= ${{matrix.CMAKE_TOOLCHAIN_FILE }} .. &&
-          make -j{nproc}"
+          docker run --rm -t -v "${PWD}:/so3" ghcr.io/smartobjectoriented/so3-env:main bash -c "mkdir usr/build && cd usr/build && cmake -Wall -Werror -Wno-dev --no-warn-unused-cli -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }} -DCMAKE_TOOLCHAIN_FILE= ${{matrix.CMAKE_TOOLCHAIN_FILE }} .. && make -j`nproc`"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,8 +29,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        CMAKE_TOOLCHAIN_FILE: ['/so3/usr/aarch64_toolchain.cmake', 
-                               '/so3/usr/arm_toolchain.cmake']
+        CMAKE_TOOLCHAIN_FILE: ['aarch64_toolchain.cmake', 
+                               'arm_toolchain.cmake']
         BUILD_TYPE: ["Debug", "Release"]
     steps:
       - name: Checkout repository
@@ -38,4 +38,4 @@ jobs:
 
       - name: Build
         run: |
-          docker run --rm -t -v "${PWD}:/so3" ghcr.io/smartobjectoriented/so3-env:main bash -c "mkdir usr/build && cd usr/build && cmake --no-warn-unused-cli -DCMAKE_C_FLAGS='-Wall -Werror -Wno-dev' -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }} -DCMAKE_TOOLCHAIN_FILE=${{matrix.CMAKE_TOOLCHAIN_FILE }} .. && make -j`nproc`"
+          docker run --rm -t -v "${PWD}:/so3" ghcr.io/smartobjectoriented/so3-env:main bash -c "mkdir usr/build && cd usr/build && cmake --no-warn-unused-cli -DCMAKE_C_FLAGS='-Werror' -Wno-dev -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }} -DCMAKE_TOOLCHAIN_FILE=../${{matrix.CMAKE_TOOLCHAIN_FILE }} .. && make -j`nproc`"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,4 +43,4 @@ jobs:
 
       - name: Build
         run: |
-          docker run --rm -t -v "${PWD}:/so3" ghcr.io/smartobjectoriented/so3-env:main bash -c "mkdir usr/build && cd usr/build && cmake -Wall -Werror -Wno-dev --no-warn-unused-cli -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }} -DCMAKE_TOOLCHAIN_FILE=${{matrix.CMAKE_TOOLCHAIN_FILE }} .. && make -j`nproc`"
+          docker run --rm -t -v "${PWD}:/so3" ghcr.io/smartobjectoriented/so3-env:main bash -c "mkdir usr/build && cd usr/build && cmake -DCMAKE_C_FLAGS="-Wall -Werror -Wno-dev" -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }} -DCMAKE_TOOLCHAIN_FILE=${{matrix.CMAKE_TOOLCHAIN_FILE }} .. && make -j`nproc`"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,11 +31,10 @@ jobs:
       matrix:
         CMAKE_TOOLCHAIN_FILE: ['aarch64_toolchain.cmake', 
                                'arm_toolchain.cmake']
-        BUILD_TYPE: ["Debug", "Release"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
 
       - name: Build
         run: |
-          docker run --rm -t -v "${PWD}:/so3" ghcr.io/smartobjectoriented/so3-env:main bash -c "mkdir usr/build && cd usr/build && cmake --no-warn-unused-cli -DCMAKE_C_FLAGS='-Werror' -Wno-dev -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }} -DCMAKE_TOOLCHAIN_FILE=../${{matrix.CMAKE_TOOLCHAIN_FILE }} .. && make -j`nproc`"
+          docker run --rm -t -v "${PWD}:/so3" ghcr.io/smartobjectoriented/so3-env:main bash -c "mkdir usr/build && cd usr/build && cmake --no-warn-unused-cli -DCMAKE_C_FLAGS='-Werror' -Wno-dev -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE=../${{matrix.CMAKE_TOOLCHAIN_FILE }} .. && make -j`nproc`"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,4 +38,4 @@ jobs:
 
       - name: Build
         run: |
-          docker run --rm -t -v "${PWD}:/so3" ghcr.io/smartobjectoriented/so3-env:main bash -c "mkdir usr/build && cd usr/build && cmake --no-warn-unused-cli -DCMAKE_C_FLAGS="-Wall -Werror -Wno-dev" -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }} -DCMAKE_TOOLCHAIN_FILE=${{matrix.CMAKE_TOOLCHAIN_FILE }} .. && make -j`nproc`"
+          docker run --rm -t -v "${PWD}:/so3" ghcr.io/smartobjectoriented/so3-env:main bash -c "mkdir usr/build && cd usr/build && cmake --no-warn-unused-cli -DCMAKE_C_FLAGS='-Wall -Werror -Wno-dev' -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }} -DCMAKE_TOOLCHAIN_FILE=${{matrix.CMAKE_TOOLCHAIN_FILE }} .. && make -j`nproc`"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,5 +44,5 @@ jobs:
       - name: Build
         run: |
           docker run --rm -t -v "${PWD}:/so3" ghcr.io/smartobjectoriented/so3-env:main bash -c "
-          mkdir usr/build && cd usr/build && cmake -Wall -Werror -Wno-dev --no-warn-unused-cli -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }} -DCMAKE_TOOLCHAIN_FILE= ${{matrix.CMAKE_TOOLCHAIN_FILE } .. &&
+          mkdir usr/build && cd usr/build && cmake -Wall -Werror -Wno-dev --no-warn-unused-cli -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }} -DCMAKE_TOOLCHAIN_FILE= ${{matrix.CMAKE_TOOLCHAIN_FILE }} .. &&
           make -j{nproc}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,25 +9,20 @@ on:
       - main
 
 jobs:
-  build-virt32:
+  build-so3:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        CONFIG: ['virt32_defconfig', 
+                 'virt64_defconfig']
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
 
       - name: Build 
         run: |
-          docker run --rm -v "${PWD}:/so3" ghcr.io/smartobjectoriented/so3-env:main bash -c "cd so3 && make virt32_defconfig && make -j`nproc`"
-
-  build-virt64:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Build
-        run: |
-          docker run --rm -v "${PWD}:/so3" ghcr.io/smartobjectoriented/so3-env:main bash -c "cd so3 && make virt64_defconfig && make -j`nproc`"
+          docker run --rm -v "${PWD}:/so3" ghcr.io/smartobjectoriented/so3-env:main bash -c "cd so3 && make ${{ matrix.CONFIG }} virt32_defconfig && make -j`nproc`"
 
   build-usr:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,4 +43,4 @@ jobs:
 
       - name: Build
         run: |
-          docker run --rm -t -v "${PWD}:/so3" ghcr.io/smartobjectoriented/so3-env:main bash -c "mkdir usr/build && cd usr/build && cmake -DCMAKE_C_FLAGS="-Wall -Werror -Wno-dev" -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }} -DCMAKE_TOOLCHAIN_FILE=${{matrix.CMAKE_TOOLCHAIN_FILE }} .. && make -j`nproc`"
+          docker run --rm -t -v "${PWD}:/so3" ghcr.io/smartobjectoriented/so3-env:main bash -c "mkdir usr/build && cd usr/build && cmake --no-warn-unused-cli -DCMAKE_C_FLAGS="-Wall -Werror -Wno-dev" -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }} -DCMAKE_TOOLCHAIN_FILE=${{matrix.CMAKE_TOOLCHAIN_FILE }} .. && make -j`nproc`"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,8 +34,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        CMAKE_TOOLCHAIN_FILE: ['../aarch64_toolchain.cmake', 
-                               '../arm_toolchain.cmake']
+        CMAKE_TOOLCHAIN_FILE: ['/so3/usr/aarch64_toolchain.cmake', 
+                               '/so3/usr/arm_toolchain.cmake']
         BUILD_TYPE: ["Debug", "Release"]
     steps:
       - name: Checkout repository
@@ -43,4 +43,4 @@ jobs:
 
       - name: Build
         run: |
-          docker run --rm -t -v "${PWD}:/so3" ghcr.io/smartobjectoriented/so3-env:main bash -c "mkdir usr/build && cd usr/build && cmake -Wall -Werror -Wno-dev --no-warn-unused-cli -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }} -DCMAKE_TOOLCHAIN_FILE= ${{matrix.CMAKE_TOOLCHAIN_FILE }} .. && make -j`nproc`"
+          docker run --rm -t -v "${PWD}:/so3" ghcr.io/smartobjectoriented/so3-env:main bash -c "mkdir usr/build && cd usr/build && cmake -Wall -Werror -Wno-dev --no-warn-unused-cli -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }} -DCMAKE_TOOLCHAIN_FILE=${{matrix.CMAKE_TOOLCHAIN_FILE }} .. && make -j`nproc`"

--- a/usr/aarch64_toolchain.cmake
+++ b/usr/aarch64_toolchain.cmake
@@ -21,8 +21,8 @@ set(CMAKE_C_COMPILER "aarch64-none-linux-gnu-gcc")
 set(CMAKE_C_LINK_EXECUTABLE "aarch64-none-linux-gnu-ld <OBJECTS> -o <TARGET>  <LINK_LIBRARIES> <LINK_FLAGS> <LINK_LIBRARIES>")
 set(CMAKE_ASM_COMPILER "aarch64-none-linux-gnu-gcc")
 
-set(CMAKE_C_FLAGS "-Wall -O0 -std=c99  -D_GNU_SOURCE -nostdlib -O0 -pipe -Wall  -D__ARM64__  \
-        -g -ffreestanding -fno-common")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -O0 -std=c99 -D_GNU_SOURCE -nostdlib -pipe \
+        -D__ARM64__ -g -ffreestanding -fno-common")
  
 set(CMAKE_ASM_FLAGS_DEBUG "-D__ASSEMBLY__")
 

--- a/usr/arm_toolchain.cmake
+++ b/usr/arm_toolchain.cmake
@@ -21,8 +21,8 @@ set(CMAKE_C_COMPILER "arm-none-eabi-gcc")
 set(CMAKE_C_LINK_EXECUTABLE "arm-none-eabi-ld <OBJECTS> -o <TARGET>  <LINK_LIBRARIES> <LINK_FLAGS> <LINK_LIBRARIES>")
 set(CMAKE_ASM_COMPILER "arm-none-eabi-gcc")
 
-set(CMAKE_C_FLAGS "-Wall -O0 -std=c99  -D_GNU_SOURCE -nostdlib -O0 -pipe -Wall  -D__ARM__ -marm  \
-        -mno-thumb-interwork -g -ffreestanding -fno-common")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -O0 -std=c99  -D_GNU_SOURCE -nostdlib \
+    -pipe -Wall  -D__ARM__ -marm -mno-thumb-interwork -g -ffreestanding -fno-common")
  
 set(CMAKE_ASM_FLAGS_DEBUG "-D__ARM__ -D__ASSEMBLY__")
 

--- a/usr/src/mydev_test.c
+++ b/usr/src/mydev_test.c
@@ -4,8 +4,8 @@
 #include <unistd.h>
 #include <assert.h>
 
-int main(void)
-{
+int main(void) {
+
 	char write_buffer[20];
 	char read_buffer[20];
 
@@ -18,4 +18,5 @@ int main(void)
 
 	printf("Wrote: %s - Read %s\n", write_buffer, read_buffer);
 	assert(!strcmp(write_buffer, read_buffer));
+	return 0;
 }

--- a/usr/src/sh.c
+++ b/usr/src/sh.c
@@ -330,6 +330,7 @@ void sigint_sh_handler(int sig) {
  * Main entry point of the shell application.
  */
 int main(int argc, char *argv[]) {
+
 	char user_input[80];
 	int i;
 	struct sigaction sa;

--- a/usr/src/sh.c
+++ b/usr/src/sh.c
@@ -333,8 +333,7 @@ void sigint_sh_handler(int sig) {
 /*
  * Main entry point of the shell application.
  */
-void main(int argc, char *argv[])
-{
+int main(int argc, char *argv[]) {
 	char user_input[80];
 	int i;
 	struct sigaction sa;

--- a/usr/src/sh.c
+++ b/usr/src/sh.c
@@ -19,9 +19,9 @@
  */
 
 #include <sys/types.h>
+#include <sys/syscall.h>
 #include <sys/wait.h>
 
-#include <errno.h>
 #include <unistd.h>
 #include <stdio.h>
 #include <string.h>

--- a/usr/src/sh.c
+++ b/usr/src/sh.c
@@ -97,24 +97,20 @@ void escape_arrow_key(char *buffer, int size) {
  * More secure way and escaped way to get user input
  */
 void get_user_input(char *buffer, int buf_size) {
-    if (buffer == NULL || buf_size <= 0) {
-        return NULL;
-    }
+	if (buffer == NULL || buf_size <= 0) {
+		return;
+	}
 
-	memset(buffer,0,buf_size);
-	
-    if (fgets(buffer, buf_size, stdin) != NULL) {
-		escape_arrow_key(buffer,buf_size);
+	memset(buffer, 0, buf_size);
+
+	if (fgets(buffer, buf_size, stdin) != NULL) {
+		escape_arrow_key(buffer, buf_size);
 		trim(buffer, buf_size);
-        size_t len = strlen(buffer);
-        if (len > 0 && buffer[len - 1] == '\n') {
-            buffer[len - 1] = '\0';
-        }
-		
-        return buffer;
-    }
-
-    return NULL;
+		size_t len = strlen(buffer);
+		if (len > 0 && buffer[len - 1] == '\n') {
+			buffer[len - 1] = '\0';
+		}
+	}
 }
 
 /*

--- a/usr/src/sh.c
+++ b/usr/src/sh.c
@@ -20,8 +20,8 @@
 
 #include <sys/types.h>
 #include <sys/wait.h>
-#include <syscall.h>
 
+#include <syscall.h>
 #include <unistd.h>
 #include <stdio.h>
 #include <string.h>

--- a/usr/src/sh.c
+++ b/usr/src/sh.c
@@ -19,8 +19,8 @@
  */
 
 #include <sys/types.h>
-#include <sys/syscall.h>
 #include <sys/wait.h>
+#include <syscall.h>
 
 #include <unistd.h>
 #include <stdio.h>

--- a/usr/src/stress/lv_demo_stress.c
+++ b/usr/src/stress/lv_demo_stress.c
@@ -430,7 +430,7 @@ static int count = 0;
             count++;
             if (count == 5)
             	for (i = 0; i < 5; i++)
-            		printf("## Elapsed time: %lld microseconds.\n", tv_end[i].tv_usec - tv_start[i].tv_usec);
+            		LV_LOG_INFO("## Elapsed time: %lld microseconds.\n", tv_end[i].tv_usec - tv_start[i].tv_usec);
 
 
             state = -2;

--- a/usr/src/stress/lvgl_perf.c
+++ b/usr/src/stress/lvgl_perf.c
@@ -45,13 +45,6 @@
 /* Screen resolution. */
 static uint32_t scr_hres, scr_vres, *fbp;
 
-/* File descriptor of the mouse and keyboard input device. */
-static int mfd;
-static int kfd;
-
-/* lvgl group for the keyboard. */
-static lv_group_t *keyboard_group;
-
 /* Used to measure the duration of execution */
 struct timeval tv_start, tv_end;
 static uint64_t delta;
@@ -216,8 +209,6 @@ int fb_init(void)
 
 int main(int argc, char **argv)
 {
-	pthread_t tick_thread;
-
 	printf("LVGL Performance test\n");
 
 	/* Initialization of lvgl. */


### PR DESCRIPTION
Fixes #102 

- There were some unused variables, returns on void function, missing returns on non-void function that are now fixed

- Changed the CMakelists found in `usr` so we can pass some CFLAGS from the command line and modified the CI to pass `-Werror` when building

- Refactored the old `build-virt32` and `build-virt64` by using a matrix making it easier to add new so3 configs to the CI

Also i've noticed that building `usr` in release mode fails in both [`arm`](https://github.com/smartobjectoriented/so3/actions/runs/13091591159/job/36528845695) and [`aarch64`](https://github.com/smartobjectoriented/so3/actions/runs/13091591159/job/36528845917) toolchains. Not really sure it's something worth fixing for now at least so i'm not adding that option to the CI