### PR TITLE
feat: virtualfb

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,9 @@ jobs:
       matrix:
         CONFIG: ['virt32_defconfig', 
                  'virt64_defconfig',
-                 'virt32_lvperf_defconfig']
+                 'virt32_lvperf_defconfig',
+                 'virt64_lvperf_defconfig'
+        ]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,8 @@ jobs:
       fail-fast: false
       matrix:
         CONFIG: ['virt32_defconfig', 
-                 'virt64_defconfig']
+                 'virt64_defconfig',
+                 'virt32_lvperf_defconfig']
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/so3/configs/virt32_lvperf_defconfig
+++ b/so3/configs/virt32_lvperf_defconfig
@@ -1,0 +1,87 @@
+CONFIG_ARCH_ARM32=y
+# CONFIG_ARCH_ARM64 is not set
+# CONFIG_SO3VIRT is not set
+CONFIG_ARCH="arm32"
+CONFIG_CROSS_COMPILE="arm-none-eabi-"
+# CONFIG_ARM_TRUSTZONE is not set
+
+#
+# Platform
+#
+CONFIG_KERNEL_VADDR=0xc0000000
+CONFIG_VIRT32=y
+# CONFIG_RPI4 is not set
+# end of Platform
+
+# CONFIG_THREAD_ENV is not set
+CONFIG_PROC_ENV=y
+
+#
+# Kernel & CPU features
+#
+# CONFIG_SMP is not set
+CONFIG_NR_CPUS=1
+CONFIG_HZ=100
+CONFIG_SCHED_FLIP_SCHEDFREQ=30
+# end of Kernel & CPU features
+
+#
+# SO3 Scheduling configuration
+#
+CONFIG_SCHED_RR=y
+# CONFIG_SCHED_PRIO is not set
+CONFIG_SCHED_FREQ_PREEMPTION=y
+# end of SO3 Scheduling configuration
+
+#
+# Drivers
+#
+CONFIG_UART=y
+CONFIG_IO_MAPPING_BASE=0xe0000000
+# CONFIG_I2C is not set
+# CONFIG_NET is not set
+CONFIG_FB=y
+CONFIG_INPUT=y
+# CONFIG_NS16550 is not set
+CONFIG_PL011_UART=y
+CONFIG_UART_LL_PADDR=0x9000000
+# CONFIG_MMC is not set
+CONFIG_RAMDEV=y
+# CONFIG_SP804 is not set
+CONFIG_ARM_TIMER=y
+CONFIG_GIC=y
+# CONFIG_PL111_CLCD is not set
+# CONFIG_QEMU_RAMFB is not set
+CONFIG_VIRTFB=y
+CONFIG_PL050_KMI=y
+# end of Drivers
+
+#
+# SO3 Applications
+#
+# CONFIG_APP_SAMPLE is not set
+# CONFIG_APP_REFSO3 is not set
+# end of SO3 Applications
+
+#
+# Filesystems
+#
+CONFIG_FS_FAT=y
+# CONFIG_ROOTFS_NONE is not set
+# CONFIG_ROOTFS_MMC is not set
+CONFIG_ROOTFS_RAMDEV=y
+# end of Filesystems
+
+#
+# IPC
+#
+CONFIG_IPC_SIGNAL=y
+CONFIG_IPC_PIPE=y
+# end of IPC
+
+CONFIG_HEAP_SIZE=32
+# CONFIG_RTOS is not set
+# CONFIG_AVZ is not set
+# CONFIG_SOO is not set
+CONFIG_MMU=y
+CONFIG_DEBUG_PRINTK=y

--- a/so3/configs/virt64_lvperf_defconfig
+++ b/so3/configs/virt64_lvperf_defconfig
@@ -1,0 +1,88 @@
+# CONFIG_ARCH_ARM32 is not set
+CONFIG_ARCH_ARM64=y
+# CONFIG_SO3VIRT is not set
+CONFIG_ARCH="arm64"
+CONFIG_CROSS_COMPILE="aarch64-none-linux-gnu-"
+# CONFIG_ARM_TRUSTZONE is not set
+CONFIG_KERNEL_VADDR=0xffff800000000000
+
+#
+# Platform
+#
+CONFIG_VIRT64=y
+# CONFIG_RPI4_64 is not set
+# CONFIG_VA_BITS_39 is not set
+CONFIG_VA_BITS_48=y
+# end of Platform
+
+# CONFIG_THREAD_ENV is not set
+CONFIG_PROC_ENV=y
+
+#
+# Kernel & CPU features
+#
+# CONFIG_SMP is not set
+CONFIG_NR_CPUS=1
+CONFIG_HZ=100
+CONFIG_SCHED_FLIP_SCHEDFREQ=30
+# end of Kernel & CPU features
+
+#
+# SO3 Scheduling configuration
+#
+CONFIG_SCHED_RR=y
+# CONFIG_SCHED_PRIO is not set
+CONFIG_SCHED_FREQ_PREEMPTION=y
+# end of SO3 Scheduling configuration
+
+#
+# Drivers
+#
+CONFIG_UART=y
+CONFIG_IO_MAPPING_BASE=0xffff900000000000
+# CONFIG_I2C is not set
+# CONFIG_NET is not set
+CONFIG_FB=y
+CONFIG_INPUT=y
+# CONFIG_NS16550 is not set
+CONFIG_PL011_UART=y
+CONFIG_UART_LL_PADDR=0x09000000
+# CONFIG_MMC is not set
+CONFIG_RAMDEV=y
+CONFIG_ARM_TIMER=y
+CONFIG_GIC=y
+# CONFIG_PL111_CLCD is not set
+# CONFIG_QEMU_RAMFB is not set
+CONFIG_VIRTFB=y
+CONFIG_PL050_KMI=y
+# end of Drivers
+
+#
+# SO3 Applications
+#
+CONFIG_APP_SAMPLE=y
+# CONFIG_APP_REFSO3 is not set
+# end of SO3 Applications
+
+#
+# Filesystems
+#
+CONFIG_FS_FAT=y
+# CONFIG_ROOTFS_NONE is not set
+# CONFIG_ROOTFS_MMC is not set
+CONFIG_ROOTFS_RAMDEV=y
+# end of Filesystems
+
+#
+# IPC
+#
+CONFIG_IPC_SIGNAL=y
+CONFIG_IPC_PIPE=y
+# end of IPC
+
+CONFIG_HEAP_SIZE=8
+# CONFIG_RTOS is not set
+# CONFIG_AVZ is not set
+# CONFIG_SOO is not set
+CONFIG_MMU=y
+# CONFIG_DEBUG_PRINTK is not set

--- a/so3/devices/fb/Kconfig
+++ b/so3/devices/fb/Kconfig
@@ -10,4 +10,10 @@ config QEMU_RAMFB
 config SOO_FB
 	bool "SOO Virtualized FB device"
 	depends on SOO && !AVZ
+
+config VIRTFB
+	bool "Virtual Framebuffer"
+	help
+		Provides a virtual framebuffer device without physical display output.
+    		Useful for containerized environments or headless systems.
 endif

--- a/so3/devices/fb/Makefile
+++ b/so3/devices/fb/Makefile
@@ -2,4 +2,4 @@ obj-$(CONFIG_PL111_CLCD) += pl111.o
 obj-$(CONFIG_QEMU_RAMFB) += ramfb.o
 
 obj-$(CONFIG_SOO_FB) += soo_fb.o
-
+obj-$(CONFIG_VIRTFB) += virtfb.o

--- a/so3/devices/fb/virtfb.c
+++ b/so3/devices/fb/virtfb.c
@@ -44,7 +44,10 @@ static void *fb_mmap(int fd, addr_t virt_addr, uint32_t page_count)
 static int fb_ioctl(int fd, unsigned long cmd, unsigned long args)
 {
 	struct devclass *dev = devclass_by_fd(fd);
-	virtfb_priv_t *priv = (virtfb_priv_t *)devclass_get_priv(dev);
+	virtfb_priv_t *priv;
+	BUG_ON(!dev);
+	priv = (virtfb_priv_t *)devclass_get_priv(dev);
+	BUG_ON(!priv);
 
 	switch (cmd) {
 	case IOCTL_HRES:
@@ -98,8 +101,8 @@ static int virtfb_init(dev_t *dev, int fdt_offset)
 				    &priv->vres);
 	BUG_ON(err < 0);
 
-	dev_set_drvdata(dev, priv);
 	devclass_register(dev, &virtfb_cdev);
+	devclass_set_priv(&virtfb_cdev, priv);
 
 	return 0;
 }

--- a/so3/devices/fb/virtfb.c
+++ b/so3/devices/fb/virtfb.c
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2025 André Costa <andre_miguel_costa@hotmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#include <process.h>
+#include <heap.h>
+
+#include <device/driver.h>
+
+#define IOCTL_HRES 1
+#define IOCTL_VRES 2
+#define IOCTL_SIZE 3
+
+typedef struct {
+	void *vaddr;
+	uint32_t hres, vres;
+} virtfb_priv_t;
+
+static void *fb_mmap(int fd, addr_t virt_addr, uint32_t page_count)
+{
+	struct devclass *dev = devclass_by_fd(fd);
+	virtfb_priv_t *priv = (virtfb_priv_t *)devclass_get_priv(dev);
+
+	priv->vaddr = malloc(page_count * PAGE_SIZE);
+	BUG_ON(!priv->vaddr);
+
+	return (void *)priv->vaddr;
+}
+
+static int fb_ioctl(int fd, unsigned long cmd, unsigned long args)
+{
+	struct devclass *dev = devclass_by_fd(fd);
+	virtfb_priv_t *priv = (virtfb_priv_t *)devclass_get_priv(dev);
+
+	switch (cmd) {
+	case IOCTL_HRES:
+		*((uint32_t *)args) = priv->hres;
+		return 0;
+
+	case IOCTL_VRES:
+		*((uint32_t *)args) = priv->vres;
+		return 0;
+
+	case IOCTL_SIZE:
+		*((uint32_t *)args) =
+			priv->hres * priv->vres * 4; /* assume 24bpp */
+		return 0;
+
+	default:
+		/* Unknown command. */
+		return -1;
+	}
+}
+
+static int fb_close(int fd)
+{
+	struct devclass *dev = devclass_by_fd(fd);
+	virtfb_priv_t *priv = (virtfb_priv_t *)devclass_get_priv(dev);
+	free(priv->vaddr);
+	return 0;
+}
+
+struct file_operations virtfb_fops = { .mmap = fb_mmap,
+				       .ioctl = fb_ioctl,
+				       .close = fb_close };
+
+struct devclass virtfb_cdev = {
+	.class = DEV_CLASS_FB,
+	.type = VFS_TYPE_DEV_FB,
+	.fops = &virtfb_fops,
+};
+
+static int virtfb_init(dev_t *dev, int fdt_offset)
+{
+	int err;
+	virtfb_priv_t *priv = (virtfb_priv_t *)malloc(sizeof(*priv));
+	BUG_ON(!priv);
+
+	err = fdt_property_read_u32(__fdt_addr, fdt_offset, "hres",
+				    &priv->hres);
+	BUG_ON(err < 0);
+
+	err = fdt_property_read_u32(__fdt_addr, fdt_offset, "vres",
+				    &priv->vres);
+	BUG_ON(err < 0);
+
+	dev_set_drvdata(dev, priv);
+	devclass_register(dev, &virtfb_cdev);
+
+	return 0;
+}
+
+REGISTER_DRIVER_POSTCORE("virt,fb", virtfb_init);

--- a/so3/dts/Makefile
+++ b/so3/dts/Makefile
@@ -2,7 +2,7 @@
 dtb-$(CONFIG_RPI4) += rpi4.dtb rpi4_avz.dtb
 dtb-$(CONFIG_RPI4_64) += rpi4_64.dtb rpi4_64_avz_vt.dtb
 dtb-$(CONFIG_VIRT64) += virt64.dtb virt64_avz_vt.dtb virt64_guest.dtb
-dtb-$(CONFIG_VIRT32) += virt32.dtb virt32_avz.dtb
+dtb-$(CONFIG_VIRT32) += virt32.dtb virt32_avz.dtb virt32_lvperf.dtb
 
 ifeq ($(CONFIG_SOO),y)
 ifeq ($(CONFIG_AVZ),)

--- a/so3/dts/Makefile
+++ b/so3/dts/Makefile
@@ -1,7 +1,7 @@
 
 dtb-$(CONFIG_RPI4) += rpi4.dtb rpi4_avz.dtb
 dtb-$(CONFIG_RPI4_64) += rpi4_64.dtb rpi4_64_avz_vt.dtb
-dtb-$(CONFIG_VIRT64) += virt64.dtb virt64_avz_vt.dtb virt64_guest.dtb
+dtb-$(CONFIG_VIRT64) += virt64.dtb virt64_avz_vt.dtb virt64_guest.dtb virt64_lvperf.dtb
 dtb-$(CONFIG_VIRT32) += virt32.dtb virt32_avz.dtb virt32_lvperf.dtb
 
 ifeq ($(CONFIG_SOO),y)

--- a/so3/dts/virt32_lvperf.dts
+++ b/so3/dts/virt32_lvperf.dts
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2025 André Costa <andre_miguel_costa@hotmail.com>
+ * 
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+/* Based on virt32.dts */
+ 
+/dts-v1/;
+ 
+/ {
+	model = "SO3 Virt32";
+	compatible = "arm,virt32";
+
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	cpus {
+		device_type = "cpu";
+		compatible = "arm,virt32";
+	};
+
+	memory {
+		device_type = "memory";
+		reg = <0x41000000 0x20000000>; /* 512 MB */
+	};
+	
+	agency {
+	        domain-size = <0x10000000>; /* 256 MB */
+	};
+
+	fw-cfg@9020000 {
+		reg = <0x9020000 0x18>;
+		compatible = "qemu,fw-cfg-mmio";
+		status = "disabled";
+	};
+	
+	/* GIC interrupt controller */
+	gic:interrupt-controller@0x08000000 {
+		compatible = "intc,gic";
+		interrupt-controller;
+		#interrupt-cells = <3>;
+		
+		reg = <0x08000000 0x1000
+			   0x08010000 0x1000>;
+			  
+		status = "ok";
+	};
+	
+	/* QEMU/virt console UART */
+	serial@09000000 {
+		compatible = "serial,pl011";
+		reg = <0x09000000 0x1000>;
+		interrupt-parent = <&gic>;
+		interrupts = <0 1 4>;
+		status = "ok";
+	};
+
+	/* Periodic timer based on ARM CP15 timer */
+	periodic-timer {
+		compatible = "arm,periodic-timer";
+		interrupt-parent = <&gic>;
+		interrupts = <1 11 4>;
+		status = "ok";
+	};
+	
+	/* Clocksource free-running timer based on ARM CP15 timer */
+	clocksource-timer {
+		compatible = "arm,clocksource-timer";
+		status = "ok";
+	};
+
+	mydev {
+		compatible = "arm,mydev";
+		status = "ok";
+	};
+
+	/* 
+	 * Virtual Framebuffer with no output
+	 */
+	virtfb {
+		compatible = "virt,fb";
+		hres = <1024>;
+		vres = <768>;
+		status = "ok";
+	};
+
+	/* PL050 PS2 Keyboard/Mouse Interface
+	 *   http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.ddi0143c/index.html
+	 */
+	kmi@0x08801000 { /* keyboard */
+		compatible = "arm,pl050,keyboard";
+		reg = <0x08801000 0x1000>;
+		interrupt-parent = <&gic>;
+		interrupts = <0 36 4>;
+
+		status = "ok";
+	};
+
+	/* PL050 PS2 Keyboard/Mouse Interface
+	 *   http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.ddi0143c/index.html
+	 */
+	kmi@0x08802000 { /* mouse */
+		compatible = "arm,pl050,mouse";
+		reg = <0x08802000  0x1000>;
+		
+		interrupt-parent = <&gic>;
+		interrupts = <0 37 4>;
+
+		status = "ok";
+	};
+	
+	/*
+        https://github.com/psawargaonkar/xvisor-next/blob/95b887c82a37c8d9ee126e061cf4d8f383ec7d01/arch/arm/board/generic/dts/vexpress/a15/vexpress-a15.dtsi
+        https://github.com/avpatel/xvisor-next/blob/master/tests/arm32/vexpress-a15/vexpress-a15-guest.dts
+   	 */
+    ethernet@1a000000 {
+        compatible = "smsc,smc911x";
+        reg = <0x1a000000 0x1000>;
+        
+    	interrupt-parent = <&gic>;
+        interrupts = <0 15 4>;
+        switch = "br0";
+
+        status = "ok";
+    };
+    	
+};

--- a/so3/dts/virt64_lvperf.dts
+++ b/so3/dts/virt64_lvperf.dts
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2025 André Costa <andre_miguel_costa@hotmail.com>
+ * 
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+ 
+/* Based on virt64.dts */
+
+/dts-v1/;
+
+/ {
+	model = "SO3 virt64 machine";
+	compatible = "arm,virt64";
+	
+	#address-cells = <2>;
+	#size-cells = <2>;
+	
+	cpus {
+		device_type = "cpu";
+		compatible = "arm,virt64";
+	};
+	
+	memory {
+		device_type = "memory";
+		reg = <0x0 0x41000000 0x0 0x20000000>; /* 512 MB */
+	};
+
+	/* GIC interrupt controller */
+	gic:interrupt-controller@0x08000000 {
+		compatible = "intc,gic";
+		interrupt-controller;
+		#interrupt-cells = <3>;
+		
+		/* GIC dist, cpu, hyp */
+		reg = <0x0 0x08000000 0x0 0x10000
+		       0x0 0x08010000 0x0 0x10000>;
+		
+		status = "ok";
+	};
+ 
+	/* virt64 console UART */
+	serial@09000000 {
+		compatible = "serial,pl011";
+		reg = <0x0 0x09000000 0x0 0x1000>;
+		interrupt-parent = <&gic>;
+		interrupts = <0 1 4>;
+		status = "ok";
+	};
+
+	/* Periodic timer based on ARM CP15 timer */
+	periodic-timer@0 {
+		compatible = "arm,periodic-timer";
+		reg = <0 0 0 0>;
+		interrupt-parent = <&gic>;
+		interrupts = <1 11 4>;
+		status = "ok";
+	};
+	
+	/* Clocksource free-running timer based on ARM CP15 timer */
+	clocksource-timer@0 {
+		compatible = "arm,clocksource-timer";
+		reg = <0 0 0 0>;
+		status = "ok";
+	};
+	
+	/* MMC */
+	mmc@1c050000 {
+		compatible = "vexpress,mmc-pl180";
+		reg = <0x0 0x1c050000 0x0 0x1000>;
+		power = <191>;
+		clkdiv = <454>;
+		caps = <0>;
+		voltages = <16744576>;
+		clock_min = <251256>;
+		clock_max = <6250000>;
+		b_max = <127>;
+
+		status = "ok";
+	};
+
+	mydev {
+		compatible = "arm,mydev";
+		status = "ok";
+	};
+
+	/* 
+	 * Virtual Framebuffer with no output
+	 */
+	virtfb {
+		compatible = "virt,fb";
+		hres = <1024>;
+		vres = <768>;
+
+		status = "ok";
+	};
+
+	/* PL050 PS2 Keyboard/Mouse Interface
+	 *   http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.ddi0143c/index.html
+	 */
+	kmi@0x08801000 { /* keyboard */
+		compatible = "arm,pl050,keyboard";
+		reg = <0x0 0x08801000 0x0 0x1000>;
+		interrupt-parent = <&gic>;
+		interrupts = <0 36 4>;
+
+		status = "ok";
+	};
+
+	/* PL050 PS2 Keyboard/Mouse Interface
+	 *   http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.ddi0143c/index.html
+	 */
+	kmi@0x08802000 { /* mouse */
+		compatible = "arm,pl050,mouse";
+		reg = <0x0 0x08802000 0x0 0x1000>;
+		
+		interrupt-parent = <&gic>;
+		interrupts = <0 37 4>;
+
+		status = "ok";
+	};
+	
+	/*
+        https://github.com/psawargaonkar/xvisor-next/blob/95b887c82a37c8d9ee126e061cf4d8f383ec7d01/arch/arm/board/generic/dts/vexpress/a15/vexpress-a15.dtsi
+        https://github.com/avpatel/xvisor-next/blob/master/tests/arm32/vexpress-a15/vexpress-a15-guest.dts
+   	 */
+    ethernet@1a000000 {
+        compatible = "smsc,smc911x";
+        reg = <0x0 0x1a000000 0x0 0x1000>;
+        
+    	interrupt-parent = <&gic>;
+        interrupts = <0 15 4>;
+        switch = "br0";
+
+        status = "ok";
+    };
+    	
+};

--- a/target/virt32_so3_standalone.its
+++ b/target/virt32_so3_standalone.its
@@ -68,7 +68,7 @@
 	};
 	
 	configurations {
-		default = "so3_lvperf_ramfs";
+		default = "so3_ramfs";
 	
 		so3_ramfs {
 			description = "SO3 kernel image including device tree";

--- a/target/virt32_so3_standalone.its
+++ b/target/virt32_so3_standalone.its
@@ -44,6 +44,16 @@
 
 		};	
 
+		lvperf_fdt {
+			description = "Flattened Device Tree blob";
+			data = /incbin/("../so3/dts/virt32_lvperf.dtb");
+			type = "flat_dt";
+			arch = "arm";
+			compression = "none";
+			load = <0x44a00000>;
+
+		};	
+
 		ramfs {
 			description = "SO3 environment minimal rootfs";
 			data = /incbin/("../rootfs/rootfs.fat");
@@ -58,12 +68,19 @@
 	};
 	
 	configurations {
-		default = "so3_ramfs";
+		default = "so3_lvperf_ramfs";
 	
 		so3_ramfs {
 			description = "SO3 kernel image including device tree";
 			kernel = "so3";
 			fdt = "fdt";
+			ramdisk = "ramfs"; 
+		};
+
+		so3_lvperf_ramfs {
+			description = "SO3 kernel image including device tree";
+			kernel = "so3";
+			fdt = "lvperf_fdt";
 			ramdisk = "ramfs"; 
 		};
 	};

--- a/target/virt64_so3_standalone.its
+++ b/target/virt64_so3_standalone.its
@@ -22,19 +22,18 @@
 	description = "Kernel and rootfs components for virt64 (armv8) environment";
 
 	images {
-
-	so3 {
+		so3 {
 			description = "SO3 OS kernel";
 			data = /incbin/("../so3/so3.bin");
 			type = "kernel";
 			arch = "arm64";
 			os = "linux";
 			compression = "none";
-            load = <0x41080000>;
+			load = <0x41080000>;
 			entry = <0x41080000>;
 		};
- 
-        fdt {
+
+		fdt {
 			description = "Flattened Device Tree blob";
 			data = /incbin/("../so3/dts/virt64.dtb");
 			type = "flat_dt";
@@ -43,17 +42,17 @@
 			load = <0x44a00000>;
 		};	
 
-        ramfs {
-        	description = "SO3 environment minimal rootfs";
+		ramfs {
+			description = "SO3 environment minimal rootfs";
 			data = /incbin/("../rootfs/rootfs.fat");
 			type = "ramdisk";
 			arch = "arm64";
 			os = "linux";
 			compression = "none";
 			load = <0x44c00000>;
-    	};
+		};
                 
-};
+	};
 
 	configurations {
 		default = "so3_ramfs";
@@ -62,10 +61,11 @@
 			description = "SO3 kernel image including device tree";
 			kernel = "so3";
 			fdt = "fdt";
-            ramdisk = "ramfs"; 
+			ramdisk = "ramfs"; 
 		};
                 
-        so3_mmc {
+
+		so3_mmc {
 			description = "SO3 kernel image including device tree";
 			kernel = "so3";
 			fdt = "fdt";

--- a/target/virt64_so3_standalone.its
+++ b/target/virt64_so3_standalone.its
@@ -42,6 +42,15 @@
 			load = <0x44a00000>;
 		};	
 
+		lvperf_fdt {
+			description = "Flattened Device Tree blob";
+			data = /incbin/("../so3/dts/virt64_lvperf.dtb");
+			type = "flat_dt";
+			arch = "arm64";
+			compression = "none";
+			load = <0x44a00000>;
+		};	
+
 		ramfs {
 			description = "SO3 environment minimal rootfs";
 			data = /incbin/("../rootfs/rootfs.fat");
@@ -63,12 +72,18 @@
 			fdt = "fdt";
 			ramdisk = "ramfs"; 
 		};
-                
 
 		so3_mmc {
 			description = "SO3 kernel image including device tree";
 			kernel = "so3";
 			fdt = "fdt";
+		};
+
+		so3_lvperf_ramfs {
+			description = "SO3 kernel image for lvgl perfomance tests";
+			kernel = "so3";
+			fdt = "lvperf_fdt";
+			ramdisk = "ramfs";
 		};
 	};
 


### PR DESCRIPTION
Added a virtualfb driver that simply allocates a virtual "framebuffer" in heap memory, making us less dependent on qemu when measuring lvgl performance

Had to create a new dts and a new so3 config to use this

Added a new `its` config inside the already existing `virt32_so3_standalone.its`. I would like to find a way to be able to switch between the two configs without having to modify the `.its` file but that seems a bit complicated. Maybe in the future we could create a separate `.its` file just for this. Let me know what you think