### PR TITLE
fix: spinlock alignement issue in aarch64 causing so3 to crash

### DIFF
--- a/so3/arch/arm64/include/asm/spinlock.h
+++ b/so3/arch/arm64/include/asm/spinlock.h
@@ -37,13 +37,13 @@ static inline int spin_trylock(spinlock_t *lock)
 {
 	uint32_t tmp;
 
-	__asm__ __volatile__("	ldaxr	%w0, [%1]\n"
-			     "	tbnz	%w0, #0, 1f\n"
+	__asm__ __volatile__("	ldaxr	%x0, [%1]\n"
+			     "	cbnz	%x0, 1f\n"
 			     "	stxr	%w0, %2, [%1]\n"
 			     "1:"
 			     : "=&r"(tmp)
-			     : "r"(&lock->lock), "r"(1)
-			     : "cc");
+			     : "r"(&lock->lock), "r"(1ULL)
+			     : "cc", "memory");
 
 	if (tmp == 0) {
 		smp_mb();
@@ -66,10 +66,10 @@ static inline void spin_unlock(spinlock_t *lock)
 {
 	smp_mb();
 
-	__asm__ __volatile__("	stlr	wzr, [%0]\n"
+	__asm__ __volatile__("	stlr	xzr, [%0]\n"
 			     "	sev"
 			     :
 			     : "r"(&lock->lock)
-			     : "cc");
+			     : "cc", "memory");
 }
 #endif /* ASM_SPINLOCK_H */

--- a/so3/arch/arm64/include/asm/spinlock.h
+++ b/so3/arch/arm64/include/asm/spinlock.h
@@ -37,6 +37,8 @@ static inline int spin_trylock(spinlock_t *lock)
 {
 	uint32_t tmp;
 
+	/* The spinlock must aligned in aarch64 */
+	BUG_ON((((uint64_t)&lock->lock) & 0x7) != 0);
 	__asm__ __volatile__("	ldaxr	%x0, [%1]\n"
 			     "	cbnz	%x0, 1f\n"
 			     "	stxr	%w0, %2, [%1]\n"

--- a/so3/include/mutex.h
+++ b/so3/include/mutex.h
@@ -58,7 +58,7 @@ void mutex_unlock(struct mutex *lock);
 void mutex_init(struct mutex *lock);
 
 int do_mutex_init(void);
-int do_mutex_lock(mutex_t *lock);
-int do_mutex_unlock(mutex_t *lock);
+int do_mutex_lock(unsigned long number);
+int do_mutex_unlock(unsigned long number);
 
 #endif /* MUTEX_H */

--- a/so3/include/mutex.h
+++ b/so3/include/mutex.h
@@ -30,10 +30,10 @@
 #include <asm/atomic.h>
 
 struct mutex {
-	/* 1: unlocked, 0: locked, negative: locked, possible waiters */
-	atomic_t count;
 	tcb_t *owner;
 	spinlock_t wait_lock;
+	/* 1: unlocked, 0: locked, negative: locked, possible waiters */
+	atomic_t count;
 
 	/* Allow to manage recursive locking */
 	uint32_t recursive_count;

--- a/so3/include/process.h
+++ b/so3/include/process.h
@@ -38,7 +38,7 @@
 #define PROC_STACK_SIZE (PROC_THREAD_MAX * THREAD_STACK_SIZE)
 
 #define FD_MAX 64
-#define N_MUTEX 10
+#define N_MUTEX 5
 
 typedef enum {
 	PROC_STATE_NEW,
@@ -126,7 +126,7 @@ struct pcb {
 	enum __ptrace_request ptrace_pending_req;
 
 	/* Mutex lock to be used in conjunction with the user space (very temporary) */
-	mutex_t lock[N_MUTEX];
+	mutex_t *lock;
 };
 typedef struct pcb pcb_t;
 

--- a/so3/include/spinlock.h
+++ b/so3/include/spinlock.h
@@ -21,12 +21,23 @@
 
 #include <asm/processor.h>
 
+#ifdef CONFIG_ARCH_ARM32
+typedef struct {
+	volatile uint32_t lock;
+} spinlock_t;
+
+#elif CONFIG_ARCH_ARM64
+
 /*
  * On Aarch64, the field has to be 64-bit aligned apparently.
  */
 typedef struct {
-	__attribute__((aligned(8))) volatile uint32_t lock;
+	volatile uint64_t lock;
 } spinlock_t;
+
+#else
+#error "Invalid ARCH config"
+#endif
 
 #include <asm/spinlock.h>
 

--- a/so3/kernel/mutex.c
+++ b/so3/kernel/mutex.c
@@ -22,6 +22,7 @@
  *
  */
 
+#include <errno.h>
 #include <mutex.h>
 #include <schedule.h>
 #include <string.h>
@@ -149,17 +150,23 @@ void mutex_unlock(struct mutex *lock)
 /*
  * The following syscall implementation are a first attempt, mainly used for debugging kernel mutexes.
  */
-int do_mutex_lock(mutex_t *lock)
+int do_mutex_lock(unsigned long number)
 {
-	mutex_lock(lock);
-
+	if (number >= N_MUTEX) {
+		set_errno(EINVAL);
+		return -1;
+	}
+	mutex_lock(&current()->pcb->lock[number]);
 	return 0;
 }
 
-int do_mutex_unlock(mutex_t *lock)
+int do_mutex_unlock(unsigned long number)
 {
-	mutex_unlock(lock);
-
+	if (number >= N_MUTEX) {
+		set_errno(EINVAL);
+		return -1;
+	}
+	mutex_unlock(&current()->pcb->lock[number]);
 	return 0;
 }
 

--- a/so3/kernel/syscalls.c
+++ b/so3/kernel/syscalls.c
@@ -218,11 +218,11 @@ long syscall_handle(syscall_args_t *a)
 	 * Mainly used for debugging purposes (kernel mutex validation) at the moment ... */
 
 	case SYSCALL_MUTEX_LOCK:
-		result = do_mutex_lock(&current()->pcb->lock[a->args[0]]);
+		result = do_mutex_lock(a->args[0]);
 		break;
 
 	case SYSCALL_MUTEX_UNLOCK:
-		result = do_mutex_unlock(&current()->pcb->lock[a->args[0]]);
+		result = do_mutex_unlock(a->args[0]);
 		break;
 
 #ifdef CONFIG_MMU


### PR DESCRIPTION
This PR aims to fix #141 

I first tried to make the `lock` inside `spinlock_t` a uint64_t and reordering the mutex arguments but that didn't work. I believe the problem is within the `pcb_t` struct which causes the misalignment. 
I tried putting the `__attribute__((aligned(8)))` inside the `pcb_t` structure but that didn't help.

So, I took it a step further and decided to put pcb mutex list in the heap so we can align it by calling as we control how the memory is aligned in the heap

I also took the liberty to:
1. Decrease the amount of mutexes per pcb
2. Make the `mutex_lock/unlock` syscalls more robust by actually checking the mutex id instead of just indexing inside the list

