### PR TITLE
fix: unused varibles in vfs

### DIFF
--- a/so3/fs/vfs.c
+++ b/so3/fs/vfs.c
@@ -291,7 +291,7 @@ int vfs_set_open_mode(int gfd, uint32_t flags_open_mode)
 
 uint32_t vfs_get_access_mode(int gfd)
 {
-	uint32_t ret;
+	uint32_t ret = 0;
 
 	mutex_lock(&vfs_lock);
 
@@ -314,7 +314,7 @@ void vfs_set_access_mode(int gfd, uint32_t flags_access_mode)
 
 uint32_t vfs_get_operating_mode(int gfd)
 {
-	uint32_t ret;
+	uint32_t ret = 0;
 	mutex_lock(&vfs_lock);
 
 	if (open_fds[gfd])

--- a/so3/include/vfs.h
+++ b/so3/include/vfs.h
@@ -176,9 +176,9 @@ void vfs_set_priv(int gfd, void *data);
 void *vfs_get_priv(int gfd);
 int vfs_clone_fd(int *gfd_src, int *gfd_dst);
 
-uint32_t vfs_get_access_mode(int fd);
-uint32_t vfs_get_open_mode(int fd);
-uint32_t vfs_get_operating_mode(int fd);
+uint32_t vfs_get_access_mode(int gfd);
+uint32_t vfs_get_open_mode(int gfd);
+uint32_t vfs_get_operating_mode(int gfd);
 
 void vfs_set_access_mode(int gfd, uint32_t flags_access_mode);
 int vfs_set_open_mode(int gfd, uint32_t flags_open_mode);


### PR DESCRIPTION
I don't really know the previous intent of these functions so i'm not sure if we should assert instead of just simply initializing at 0