### PR TITLE
build: add missing dependencies to env dockerfile

### DIFF
--- a/docker/Dockerfile.env
+++ b/docker/Dockerfile.env
@@ -19,6 +19,9 @@ RUN apt install python3-venv -y
 RUN apt install ninja-build -y
 RUN apt install git -y
 RUN apt install cmake -y
+RUN apt install python3-pip -y
+
+RUN pip3 install pcpp
 
 # Download aarch64-none-linux-gnu toolchain
 RUN wget https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-a/10.3-2021.07/binrel/gcc-arm-10.3-2021.07-x86_64-aarch64-none-linux-gnu.tar.xz


### PR DESCRIPTION
Splitting PR #154 into two

This one adds the necessary dependencies to the so3-env image while #154 will actually do the lvgl update. This will ensure the CI isn't broken 