### PR TITLE
chore: update LVGL to v9.3

### DIFF
--- a/target/virt64.its
+++ b/target/virt64.its
@@ -1,1 +1,1 @@
-virt64_so3_guest.its
+virt64_so3_standalone.its

--- a/usr/lib/CMakeLists.txt
+++ b/usr/lib/CMakeLists.txt
@@ -3,10 +3,12 @@ set(ORIGINAL_C_FLAGS "${CMAKE_C_FLAGS}")
 string(REPLACE "-Werror" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
 
 add_subdirectory(libc)
+set(LV_BUILD_CONF_DIR
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    CACHE PATH "Directory containing lv_conf.h")
 add_subdirectory(lvgl)
 
 set(CMAKE_C_FLAGS "${ORIGINAL_C_FLAGS}")
 
-# Non external libs 
-
+# Non external libs
 add_subdirectory(slv)


### PR DESCRIPTION
Last week LVGL v9.3 was released. This updates the submodule, adds a new required build config and also makes `virt64.its` point to `virt64_so3_standalone.its` again as it was changed by mistake i believe