### PR TITLE
chore: enhance debugging capabilities on lvperf docker images

### DIFF
--- a/docker/scripts/run.sh
+++ b/docker/scripts/run.sh
@@ -5,6 +5,7 @@ set -e
 ROOTFS_PATH="/persistence/rootfs.fat.$PLATFORM"
 FILESYSTEM_PATH="/persistence/sdcard.img.$PLATFORM"
 
+
 mount_loop_partition() {
   image_path="$1"
   mount_point="$2"
@@ -54,7 +55,12 @@ build_usr()  {
 
   cd usr
 
-  ./build.sh -r
+  if [ -n "$SO3_USR_DEBUG" ]; then
+    ./build.sh
+  else
+    ./build.sh -r
+  fi
+
   if [ $? -ne '0' ]; then 
     exit 1
   fi
@@ -105,7 +111,11 @@ else
     exit 1
 fi
 
-qemu-system-${QEMU_ARCH} \
+if [ -n "$SO3_USR_DEBUG" ]; then
+  QEMU_DEBUG_ARGS="-S -gdb tcp::1234"
+fi
+
+qemu-system-${QEMU_ARCH} ${QEMU_DEBUG_ARGS} \
   -semihosting \
   -smp 2 \
   -icount shift=0,sleep=on,align=on \

--- a/usr/CMakeLists.txt
+++ b/usr/CMakeLists.txt
@@ -52,6 +52,10 @@ add_link_options(-T ${CMAKE_SOURCE_DIR}/lib/libc/aarch64.lds -N -warn-common
 
 endif()
 
+if(CMAKE_BUILD_TYPE MATCHES "Debug")
+	add_compile_options(-ggdb)
+endif()
+
 # All related libraries used by the linker
 add_subdirectory(lib)
 


### PR DESCRIPTION
See related issue for context #178 

This adds an env variable that will make our `run.sh` script build user space in debug mode and launch QEMU with the `-S` and `-gdb tcp::1234` flags 