### PR TITLE
Fix typo in sh.c main function comment (#195)

### DIFF
--- a/usr/src/sh.c
+++ b/usr/src/sh.c
@@ -329,7 +329,7 @@ void sigint_sh_handler(int sig)
 	printf("%s", prompt);
 	fflush(stdout);
 }
-/*d
+/*
  * Main entry point of the shell application.
  */
 int main(int argc, char *argv[])


### PR DESCRIPTION
This PR fixes a small typo in the comment above the main function in `sh.c`:

- Changed `/*d` to `/*`

Closes #195 