### PR TITLE
add format(printf) attribute and fix warnings

### DIFF
--- a/so3/apps/sample.c
+++ b/so3/apps/sample.c
@@ -77,7 +77,7 @@ void *app_thread_main(void *args)
 	while (threads != 4)
 		;
 
-	printk("### Total = %lld\n", count);
+	printk("### Total = %d\n", count);
 
 	while (1)
 		;

--- a/so3/arch/arm64/domain.c
+++ b/so3/arch/arm64/domain.c
@@ -107,7 +107,7 @@ void __setup_dom_pgtable(struct domain *d, addr_t paddr_start, unsigned long map
 	printk("   Map size (bytes) 		: 0x%lx\n", map_size);
 
 	printk("   Intermediate phys address    : 0x%lx\n", memslot[slotID].ipa_addr);
-	printk("   Stage-2 vttbr 		: (va) 0x%lx - (pa) 0x%lx\n", new_pt, __pa(new_pt));
+	printk("   Stage-2 vttbr 		: (va) 0x%p - (pa) 0x%lx\n", new_pt, __pa(new_pt));
 
 	d->pagetable_vaddr = (addr_t) new_pt;
 	d->pagetable_paddr = __pa(new_pt);

--- a/so3/arch/arm64/mmu.c
+++ b/so3/arch/arm64/mmu.c
@@ -761,7 +761,7 @@ void dump_pgtable(void *l0pgtable)
 	for (i = 0; i < TTB_L0_ENTRIES; i++) {
 		l0pte = __l0pgtable + i;
 		if ((i != 0xe0) && *l0pte) {
-			lprintk("  - L0 pte@%lx (idx %x) mapping %lx content: %lx\n", __l0pgtable + i, i, i << TTB_I0_SHIFT,
+			lprintk("  - L0 pte@%p (idx %lx) mapping %lx content: %lx\n", __l0pgtable + i, i, i << TTB_I0_SHIFT,
 				*l0pte);
 			BUG_ON(pte_type(l0pte) != PTE_TYPE_TABLE);
 
@@ -770,14 +770,14 @@ void dump_pgtable(void *l0pgtable)
 				l1pte = ((u64 *) __va(*l0pte & TTB_L0_TABLE_ADDR_MASK)) + j;
 				if (*l1pte) {
 					if (pte_type(l1pte) == PTE_TYPE_TABLE) {
-						lprintk("    (TABLE) L1 pte@%lx (idx %x) mapping %lx content: %lx\n", l1pte, j,
+						lprintk("    (TABLE) L1 pte@%p (idx %lx) mapping %lx content: %lx\n", l1pte, j,
 							(i << TTB_I0_SHIFT) + (j << TTB_I1_SHIFT), *l1pte);
 
 						for (k = 0; k < TTB_L2_ENTRIES; k++) {
 							l2pte = ((u64 *) __va(*l1pte & TTB_L1_TABLE_ADDR_MASK)) + k;
 							if (*l2pte) {
 								if (pte_type(l2pte) == PTE_TYPE_TABLE) {
-									lprintk("    (TABLE) L2 pte@%lx (idx %x) mapping %lx content: %lx\n",
+									lprintk("    (TABLE) L2 pte@%p (idx %lx) mapping %lx content: %lx\n",
 										l2pte, k,
 										(i << TTB_I0_SHIFT) + (j << TTB_I1_SHIFT) +
 											(k << TTB_I2_SHIFT),
@@ -788,7 +788,7 @@ void dump_pgtable(void *l0pgtable)
 												      TTB_L2_TABLE_ADDR_MASK)) +
 											l;
 										if (*l3pte)
-											lprintk("      (PAGE) L3 pte@%lx (idx %x) mapping %lx content: %lx\n",
+											lprintk("      (PAGE) L3 pte@%p (idx %lx) mapping %lx content: %lx\n",
 												l3pte, l,
 												(i << TTB_I0_SHIFT) +
 													(j << TTB_I1_SHIFT) +
@@ -799,7 +799,7 @@ void dump_pgtable(void *l0pgtable)
 								} else {
 									/* Necessary of BLOCK type */
 									BUG_ON(pte_type(l2pte) != PTE_TYPE_BLOCK);
-									lprintk("      (PAGE) L2 pte@%lx (idx %x) mapping %lx content: %lx\n",
+									lprintk("      (PAGE) L2 pte@%p (idx %lx) mapping %lx content: %lx\n",
 										l2pte, k,
 										(i << TTB_I0_SHIFT) + (j << TTB_I1_SHIFT) +
 											(k << TTB_I2_SHIFT),
@@ -811,7 +811,7 @@ void dump_pgtable(void *l0pgtable)
 						/* Necessary of BLOCK type */
 						BUG_ON(pte_type(l1pte) != PTE_TYPE_BLOCK);
 
-						lprintk("      (PAGE) L1 pte@%lx (idx %x) mapping %lx content: %lx\n", l1pte, j,
+						lprintk("      (PAGE) L1 pte@%p (idx %lx) mapping %lx content: %lx\n", l1pte, j,
 							(i << TTB_I0_SHIFT) + (j << TTB_I1_SHIFT), *l1pte);
 					}
 				}

--- a/so3/arch/arm64/traps.c
+++ b/so3/arch/arm64/traps.c
@@ -183,7 +183,7 @@ void trap_handle(cpu_regs_t *regs)
 			break;
 
 		case PSCI_0_2_FN64_CPU_ON:
-			printk("Power on CPU #%d starting at %x...\n", regs->x1 & 3, regs->x2);
+			printk("Power on CPU #%ld starting at %lx...\n", regs->x1 & 3, regs->x2);
 
 			cpu_entrypoint = regs->x2;
 			smp_trigger_event(regs->x1 & 3);

--- a/so3/avz/include/avz/console.h
+++ b/so3/avz/include/avz/console.h
@@ -20,6 +20,7 @@
 #define AVZ_CONSOLE_H
 
 #include <stdarg.h>
+#include <compiler.h>
 
 #include <avz/uapi/avz.h>
 
@@ -27,7 +28,7 @@ void init_console(void);
 
 extern void (*__printch)(char c);
 
-void lprintk(char *format, ...);
+void lprintk(char *format, ...) __attribute_printf(1, 2);
 void lprintk_buffer(void *buffer, uint32_t n);
 void lprintk_buffer_separator(void *buffer, uint32_t n, char separator);
 

--- a/so3/avz/kernel/ME_build.c
+++ b/so3/avz/kernel/ME_build.c
@@ -54,7 +54,7 @@ int construct_ME(struct domain *d)
 	d->max_pages = ~0U;
 
 	d->avz_shared->nr_pages = memslot[slotID].size >> PAGE_SHIFT;
-	printk("Max dom size %d\n", memslot[slotID].size);
+	printk("Max dom size %ld\n", memslot[slotID].size);
 
 	printk("Domain length = %lu pages.\n", d->avz_shared->nr_pages);
 

--- a/so3/avz/kernel/agency_build.c
+++ b/so3/avz/kernel/agency_build.c
@@ -51,7 +51,7 @@ int construct_agency(struct domain *d)
 	d->max_pages = ~0U;
 
 	printk("-> Agency base address from ITB: %lx\n", memslot[MEMSLOT_AGENCY].base_paddr);
-	printk("-> Max dom size %d\n", memslot[MEMSLOT_AGENCY].size);
+	printk("-> Max dom size %ld\n", memslot[MEMSLOT_AGENCY].size);
 
 	ASSERT(d);
 
@@ -68,7 +68,7 @@ int construct_agency(struct domain *d)
 	printk("AVZ Hypervisor vaddr: 0x%lx\n", CONFIG_KERNEL_VADDR);
 	printk("Agency FDT device tree: 0x%lx (phys)\n", d->avz_shared->fdt_paddr);
 
-	printk("Shared AVZ page is located at: %lx\n", d->avz_shared);
+	printk("Shared AVZ page is located at: %p\n", d->avz_shared);
 
 	initialize_hyp_dom_stack(d, pa_to_ipa(MEMSLOT_AGENCY, d->avz_shared->fdt_paddr), memslot[MEMSLOT_AGENCY].entry_addr);
 

--- a/so3/avz/kernel/domain_utils.c
+++ b/so3/avz/kernel/domain_utils.c
@@ -245,8 +245,8 @@ void loadAgency(void)
 	/* Get the RAM information of the board */
 	early_memory_init(__fdt_addr);
 
-	lprintk("  AVZ DT at physical address : %lx\n", __fdt_addr);
-	lprintk("  AVZ memory descriptor : found %d MB of RAM at 0x%08X\n", mem_info.size / SZ_1M, mem_info.phys_base);
+	lprintk("  AVZ DT at physical address : %p\n", __fdt_addr);
+	lprintk("  AVZ memory descriptor : found %ld MB of RAM at 0x%08lX\n", mem_info.size / SZ_1M, mem_info.phys_base);
 
 	memslot[MEMSLOT_AVZ].base_paddr = mem_info.phys_base;
 	memslot[MEMSLOT_AVZ].base_vaddr = CONFIG_KERNEL_VADDR;
@@ -290,14 +290,14 @@ void loadME(unsigned int slotID, void *itb)
 				lprintk("!! Missing load-addr in the agency node !!\n");
 				BUG();
 			}
-			lprintk("ITB: Domain load addr = 0x%lx\n", dom_addr);
+			lprintk("ITB: Domain load addr = 0x%x\n", dom_addr);
 
 			ret = fdt_property_read_u32(itb, nodeoffset, "entry", &entry_addr);
 			if (ret == -1) {
 				lprintk("!! Missing entry in the agency node !!\n");
 				BUG();
 			}
-			lprintk("ITB: Domain entry addr = 0x%lx\n", entry_addr);
+			lprintk("ITB: Domain entry addr = 0x%x\n", entry_addr);
 
 			/* Get the pointer to the OS binary image from the ITB we got from the user space. */
 			ret = fit_image_get_data_and_size(itb, nodeoffset, (const void **) &ME_vaddr, &ME_size);

--- a/so3/avz/kernel/keyhandler.c
+++ b/so3/avz/kernel/keyhandler.c
@@ -110,7 +110,7 @@ static void dump_domains(unsigned char key)
 
 		printk("General information for domain %u:\n", d->avz_shared->domID);
 
-		printk("    dying=%d nr_pages=%d max_pages=%u\n", d->is_dying, d->avz_shared->nr_pages, d->max_pages);
+		printk("    dying=%d nr_pages=%ld max_pages=%u\n", d->is_dying, d->avz_shared->nr_pages, d->max_pages);
 
 		printk("VCPU information and callbacks for domain %u:\n", d->avz_shared->domID);
 

--- a/so3/devices/irq/gic.c
+++ b/so3/devices/irq/gic.c
@@ -148,7 +148,7 @@ void fdt_interrupt_node(int fdt_offset, irq_def_t *irq_def)
 
 	} else {
 		/* Unsupported size of interrupts property */
-		lprintk("%s: unsupported size of interrupts property\n");
+		LOG_ERROR("unsupported size of interrupts property\n");
 		BUG();
 	}
 }

--- a/so3/include/common.h
+++ b/so3/include/common.h
@@ -24,6 +24,7 @@
 #ifndef __ASSEMBLY__
 
 #include <types.h>
+#include <compiler.h>
 #include <printk.h>
 #include <string.h>
 
@@ -91,7 +92,7 @@ extern addr_t __stack_bottom[];
 void kernel_panic(void);
 void _bug(char *file, int line);
 
-static inline void panic(const char *fmt, ...)
+__attribute_printf(1, 2) static inline void panic(const char *fmt, ...)
 {
 	va_list args;
 	static char buf[128];
@@ -103,8 +104,6 @@ static inline void panic(const char *fmt, ...)
 	printk("%s", buf);
 	kernel_panic();
 }
-
-extern void panic(const char *format, ...) __attribute__((format(printf, 1, 2)));
 
 #define BUG() _bug(__FILE__, __LINE__)
 #define BUG_ON(p)                \

--- a/so3/include/compiler.h
+++ b/so3/include/compiler.h
@@ -49,6 +49,16 @@ typedef long int intptr_t;
 
 #define __must_check __attribute__((warn_unused_result))
 
+/**
+ * printf/scanf attributes to let the compiler check that supplied arguments match
+ * the specified format.
+ *
+ * @param f index of the string format in function's argument list (starting form 1)
+ * @param a index of the first argument associated with the format (starting form 1)
+ */
+#define __attribute_printf(f, a) __attribute__((format(printf, f, a)))
+#define __attribute_scanf(f, a) __attribute__((format(scanf, f, a)))
+
 #define offsetof(a, b) __builtin_offsetof(a, b)
 
 #ifdef GCC_HAS_VISIBILITY_ATTRIBUTE

--- a/so3/include/printk.h
+++ b/so3/include/printk.h
@@ -21,13 +21,14 @@
 
 #include <stdarg.h>
 #include <types.h>
+#include <compiler.h>
 
-void lprintk(char *format, ...);
-void llprintk(char *format, ...);
+void lprintk(char *format, ...) __attribute_printf(1, 2);
+void llprintk(char *format, ...) __attribute_printf(1, 2);
 
 void lprintk_buffer(void *buffer, uint32_t n);
 
-void printk(const char *fmt, ...);
+void printk(const char *fmt, ...) __attribute_printf(1, 2);
 
 #ifndef __ASSEMBLY__
 

--- a/so3/include/string.h
+++ b/so3/include/string.h
@@ -25,6 +25,7 @@
 
 #include <stdarg.h>
 #include <types.h>
+#include <compiler.h>
 
 void *memchr(const void *, int, size_t);
 int memcmp(const void *, const void *, size_t);
@@ -46,8 +47,8 @@ size_t strnlen(const char *s, size_t count);
 
 char *strdup(const char *s);
 
-int sprintf(char *buf, const char *fmt, ...);
-int scnprintf(char *buf, size_t size, const char *fmt, ...);
+int sprintf(char *buf, const char *fmt, ...) __attribute_printf(2, 3);
+int scnprintf(char *buf, size_t size, const char *fmt, ...) __attribute_printf(3, 4);
 
 char *strcpy(char *, const char *);
 size_t strlen(const char *);
@@ -57,12 +58,12 @@ char *strcat(char *dest, const char *src);
 int vsprintf(char *s, const char *fmt, va_list ap);
 int vsnprintf(char *buf, size_t size, const char *fmt, va_list args);
 int vsscanf(const char *buf, const char *fmt, va_list args);
-int sscanf(const char *buf, const char *fmt, ...);
-int sprintf(char *buf, const char *fmt, ...);
-int snprintf(char *buf, size_t size, const char *fmt, ...);
+int sscanf(const char *buf, const char *fmt, ...) __attribute_scanf(2, 3);
+int sprintf(char *buf, const char *fmt, ...) __attribute_printf(2, 3);
+int snprintf(char *buf, size_t size, const char *fmt, ...) __attribute_printf(3, 4);
 
 char *kvasprintf(const char *fmt, va_list ap);
-char *kasprintf(const char *fmt, ...);
+char *kasprintf(const char *fmt, ...) __attribute_printf(1, 2);
 
 unsigned long simple_strtoul(const char *cp, char **endp, unsigned int base);
 long simple_strtol(const char *cp, char **endp, unsigned int base);

--- a/so3/kernel/futex.c
+++ b/so3/kernel/futex.c
@@ -156,7 +156,7 @@ SYSCALL_DEFINE6(futex, uint32_t *, uaddr, int, op, uint32_t, val, const struct t
 	case FUTEX_UNLOCK_PI:
 	case FUTEX_TRYLOCK_PI:
 	case FUTEX_WAIT_BITSET:
-		printk("Futex cmd '%d' not supported !\n");
+		printk("Futex cmd '%d' not supported !\n", cmd);
 		return -EINVAL;
 	}
 

--- a/so3/kernel/process.c
+++ b/so3/kernel/process.c
@@ -260,7 +260,7 @@ void dump_proc_pages(pcb_t *pcb)
 
 	LOG_INFO("----- Dump of pages belonging to proc: %d -----\n\n", pcb->pid);
 	list_for_each_entry(cur, &pcb->page_list, list)
-		LOG_INFO("   -- page: %p  pfn: %x   refcount: %d\n", cur->page, page_to_pfn(cur->page), cur->page->refcount);
+		LOG_INFO("   -- page: %p  pfn: %lx   refcount: %d\n", cur->page, page_to_pfn(cur->page), cur->page->refcount);
 	LOG_INFO("\n");
 }
 

--- a/so3/kernel/syscalls.c
+++ b/so3/kernel/syscalls.c
@@ -66,7 +66,7 @@ long syscall_handle(syscall_args_t *syscall_args)
 	__get_syscall_args_ext(&syscall_no);
 
 	if ((syscall_no >= NR_SYSCALLS) || (syscall_table[syscall_no] == NULL)) {
-		printk("%s: unhandled syscall: %d\n", __func__, syscall_no);
+		printk("%s: unhandled syscall: %ld\n", __func__, syscall_no);
 		return -ENOSYS;
 	}
 

--- a/so3/kernel/timer.c
+++ b/so3/kernel/timer.c
@@ -346,7 +346,7 @@ again:
 static void dump_timer(struct timer *t, u64 now)
 {
 	/* We convert 1000 to u64 in order to use the well-implemented __aeabi_uldivmod function */
-	lprintk("  expires = %llu, now = %llu, expires - now = %llu ns timer=%p cb=%p(%p) cpu=%d\n", t->expires, now,
+	lprintk("  expires = %lu, now = %lu, expires - now = %lu ns timer=%p cb=%p(%p) cpu=%d\n", t->expires, now,
 		t->expires - now, t, t->function, t->data, t->cpu);
 }
 

--- a/so3/mm/heap.c
+++ b/so3/mm/heap.c
@@ -391,7 +391,7 @@ next_list:
 	if (!victim) {
 		/* not enough free space left */
 		/* FIXME: do sbrk() here to request more space. Request less space in init() */
-		LOG_CRITICAL("[malloc] Not enough free space, requested = %x", requested);
+		LOG_CRITICAL("[malloc] Not enough free space, requested = %lx", requested);
 
 		spin_unlock_irqrestore(&heap_lock, flags);
 
@@ -519,7 +519,7 @@ void free(void *ptr)
 	flags = spin_lock_irqsave(&heap_lock);
 
 	if (chunk->sig != CHUNK_SIG) {
-		LOG_CRITICAL("Heap failure: already free'd chunk for address %x...", ptr);
+		LOG_CRITICAL("Heap failure: already free'd chunk for address %p...", ptr);
 		kernel_panic();
 	}
 

--- a/so3/mm/memory.c
+++ b/so3/mm/memory.c
@@ -354,7 +354,7 @@ void io_unmap(addr_t vaddr)
 	}
 
 	if (cur == NULL) {
-		LOG_CRITICAL("io_unmap failure: did not find entry for vaddr %x", vaddr);
+		LOG_CRITICAL("io_unmap failure: did not find entry for vaddr %lx", vaddr);
 		kernel_panic();
 	}
 

--- a/so3/soo/drivers/vlogsfront/vlogs.c
+++ b/so3/soo/drivers/vlogsfront/vlogs.c
@@ -246,7 +246,7 @@ static int vlogs_cwrite(int fd, const void *buffer, int count)
 {
 	static char msg[1024];
 
-	sprintf(msg, "[ME:%d] %s", get_ME_desc()->capsuleID, buffer);
+	sprintf(msg, "[ME:%d] %s", get_ME_desc()->capsuleID, (const char *) buffer);
 
 	vlogs_write((char *) msg);
 

--- a/so3/soo/include/soo/console.h
+++ b/so3/soo/include/soo/console.h
@@ -22,6 +22,7 @@
 
 #include <types.h>
 #include <soo/soo.h>
+#include <compiler.h>
 
 #define CONSOLEIO_BUFFER_SIZE 256
 
@@ -35,7 +36,7 @@ void init_console(void);
 void avz_printch(char c);
 void avz_printstr(char *str);
 
-void lprintk(char *format, ...);
+void lprintk(char *format, ...) __attribute_printf(1, 2);
 void lprintk_buffer(void *buffer, uint32_t n);
 void lprintk_buffer_separator(void *buffer, uint32_t n, char separator);
 

--- a/so3/soo/include/soo/dev/vlogs.h
+++ b/so3/soo/include/soo/dev/vlogs.h
@@ -19,6 +19,7 @@
 #ifndef VLOGS_H
 #define VLOGS_H
 
+#include <compiler.h>
 #include <soo/ring.h>
 #include <soo/vdevfront.h>
 #include <soo/gnttab.h>
@@ -50,6 +51,6 @@ typedef struct {
 
 bool vlogs_ready(void);
 
-void vlogs_write(const char *fmt, ...);
+void vlogs_write(const char *fmt, ...) __attribute_printf(1, 2);
 
 #endif /* VLOGS_H */

--- a/so3/soo/include/soo/vbus.h
+++ b/so3/soo/include/soo/vbus.h
@@ -20,6 +20,7 @@
 #ifndef VBUS_H
 #define VBUS_H
 
+#include <compiler.h>
 #include <completion.h>
 
 #include <device/driver.h>
@@ -134,12 +135,10 @@ void vbus_transaction_start(struct vbus_transaction *t);
 void vbus_transaction_end(struct vbus_transaction t);
 
 /* Single read and scanf: returns -errno or num scanned if > 0. */
-int vbus_scanf(struct vbus_transaction t, const char *dir, const char *node, const char *fmt, ...)
-	__attribute__((format(scanf, 4, 5)));
+int vbus_scanf(struct vbus_transaction t, const char *dir, const char *node, const char *fmt, ...) __attribute_scanf(4, 5);
 
 /* Single printf and write: returns -errno or 0. */
-void vbus_printf(struct vbus_transaction t, const char *dir, const char *node, const char *fmt, ...)
-	__attribute__((format(printf, 4, 5)));
+void vbus_printf(struct vbus_transaction t, const char *dir, const char *node, const char *fmt, ...) __attribute_printf(4, 5);
 
 /* Generic read function: NULL-terminated triples of name,
  * sprintf-style type string, and pointer. Returns 0 or errno.*/
@@ -198,7 +197,7 @@ void vbus_probe_frontend_init(void);
 
 void vbus_watch_path(struct vbus_device *dev, char *path, struct vbus_watch *watch, void (*callback)(struct vbus_watch *));
 void vbus_watch_pathfmt(struct vbus_device *dev, struct vbus_watch *watch, void (*callback)(struct vbus_watch *),
-			const char *pathfmt, ...) __attribute__((format(printf, 4, 5)));
+			const char *pathfmt, ...) __attribute_printf(4, 5);
 
 int vbus_grant_ring(struct vbus_device *dev, unsigned long ring_pfn);
 

--- a/so3/soo/kernel/soo_guest_activity.c
+++ b/so3/soo/kernel/soo_guest_activity.c
@@ -237,7 +237,7 @@ void perform_task(dc_event_t dc_event)
 		break;
 
 	default:
-		lprintk("Wrong DC event %d\n", avz_shared->dc_event);
+		lprintk("Wrong DC event %d\n", dc_event);
 	}
 
 	tell_dc_stable(dc_event);

--- a/so3/soo/kernel/soo_id.c
+++ b/so3/soo/kernel/soo_id.c
@@ -125,7 +125,7 @@ void vbstore_ME_ID_populate(void)
 	vbus_mkdir(VBT_NIL, rootname, entry);
 
 	sprintf(rootname, "soo/me/%d", ME_domID());
-	sprintf(entry, "%llx", spid);
+	sprintf(entry, "%lx", spid);
 
 	vbus_write(VBT_NIL, rootname, "spid", entry);
 


### PR DESCRIPTION
That PR add the `__attribute__(fromat(printf/scanf, ...))` to all printf/scanf like functions.
This allows the compiler to print warning when the attributes list doesn't match the format string (like it would be done with libc printf).

closes #240 

