### PR TITLE
config: default SO3 boot chain to bare U-Boot (no ATF/OP-TEE)

### DIFF
--- a/build/conf/local.conf
+++ b/build/conf/local.conf
@@ -161,7 +161,7 @@ IB_CONFIG:avz:verdin-imx8mp ?= "verdin-imx8mp_avz_defconfig"
 #   "full"       ATF + OP-TEE (BL32) + U-Boot in flash0.img — secure world.
 # The flash0.img assembly lives in meta-bsp/.../bsp_virt64.inc
 # (__do_platform_boot_chain); st.sh picks ATF vs bare from its presence.
-IB_BOOT_CHAIN = "full"
+IB_BOOT_CHAIN ?= ""
 
 # ATF / OP-TEE platform identifiers for QEMU virt (used when IB_BOOT_CHAIN
 # is "atf+uboot" or "full"). Mirrors edgem1's virt64 settings.


### PR DESCRIPTION
## Summary

The SO3 standalone default on `virt64` was set to `IB_BOOT_CHAIN = "full"`, which pulled **ATF + OP-TEE + AVZ** into the boot chain and assembled a secure-world `flash0.img`. That is appropriate for the e1c capsule model, but not for the plain SO3-at-EL1 default — and it contradicted the inline documentation in `build/conf/local.conf`, which already describes the empty value as the SO3 default and prescribes a *weak* assignment so a capsule layer can override it.

This sets:

```
IB_BOOT_CHAIN ?= ""
```

so the default build is **bare U-Boot** (no ATF, no OP-TEE, no AVZ), while a downstream capsule layer can still select `"full"`.

## Why

- `bsp.bbclass` only wires `atf`/`optee`/`avz` dependencies into `do_build`/`do_deploy_boot_chain` when `IB_BOOT_CHAIN` is `atf+uboot`/`full`. With `""`, none are pulled.
- The `?=` (weak) form matches the documented intent: the e1c capsule layer overrides it to `"full"`.

## Verification

- Clean `bsp-so3` build: **42-task graph, all succeeded, zero `atf`/`optee`/`avz` tasks, no `flash0.img`** produced.
- QEMU boot (`st.sh`): bare **U-Boot 2022.04** loaded via `-kernel` at EL1 → SO3 FIT image → kernel → userspace:
  ```
  U-Boot 2022.04 (Jun 30 2026 ...)
  ...
  Starting kernel ...
  ********** Smart Object Oriented SO3 Operating System **********
  [SO3 USR] Starting the initial process
  SO3 Init Program :)
  ```
  No aborts, panics, or exceptions.