### PR TITLE
build: fail usr-so3 deploy clearly when the user space is not built

### DIFF
--- a/build/meta-usr/recipes-usr/so3/usr-so3_1.0.bb
+++ b/build/meta-usr/recipes-usr/so3/usr-so3_1.0.bb
@@ -76,10 +76,17 @@ python do_deploy() {
     d.setVar('ROOTFS_FILENAME', '')
 
     if os.path.isdir(d.getVar('IB_ROOTFS_PATH')):
-        __do_rootfs_mount(d)
-        
         src_dir = os.path.join(d.getVar('IB_TARGET'), 'build', 'deploy')
         dst_dir = os.path.join(d.getVar('IB_ROOTFS_PATH'), 'fs')
+
+        # The user space must be built before it can be deployed. Bail out
+        # early — before mounting the rootfs, so a missing build does not
+        # leave a dangling loop mount — with an actionable message.
+        if not os.path.isdir(src_dir):
+            bb.fatal("SO3 user space not built: '%s' is missing. "
+                     "Build it first with 'build.sh -x usr-so3' (or 'build.sh bsp-so3')." % src_dir)
+
+        __do_rootfs_mount(d)
 
         # The SO3 rootfs.fat is loop-mounted at rootfs/fs as root
         # (rootfs/mount.sh), so the copy must be privileged. The split


### PR DESCRIPTION
## Problem
On a fresh clone (or when only the kernel was built), `deploy.sh bsp-so3` fails with an opaque error:

```
rsync: change_dir ".../so3/usr/build/deploy" failed: No such file or directory (2)
rsync error: some files/attrs were not transferred (code 23)
```

`usr-so3:do_deploy` rsync'd from `so3/usr/build/deploy/` without checking it exists, and it had already loop-mounted the rootfs — so the abort also left a **dangling mount** behind.

## Fix
Check the deploy source dir **before** mounting the rootfs, and `bb.fatal` with an actionable message if it's missing:

```
SO3 user space not built: '.../so3/usr/build/deploy' is missing.
Build it first with 'build.sh -x usr-so3' (or 'build.sh bsp-so3').
```

Because the check runs before `__do_rootfs_mount`, a missing build no longer leaves a dangling loop mount. No behaviour change when the user space is built.