### PR TITLE
avz: finish the e1c-boot → guest-boot rename in AVZ source

### DIFF
--- a/build/meta-bsp/classes/bsp.bbclass
+++ b/build/meta-bsp/classes/bsp.bbclass
@@ -130,7 +130,7 @@ inherit filesystem
 #
 # Per-platform bootloader assembly lives in bsp_<platform>.inc as
 # __do_platform_boot_chain(d). The AVZ ITB build is generic: mkimage on
-# ${IB_DIR}/linux/target/${IB_PLATFORM}_avz.its.
+# ${IB_DIR}/linux/images/${IB_PLATFORM}_avz.its.
 
 # Boot-chain dependencies gate on IB_BOOT_CHAIN:
 #   "uboot"      → only u-boot (no ATF, OP-TEE, AVZ pulled in)

--- a/build/meta-bsp/classes/bsp.bbclass
+++ b/build/meta-bsp/classes/bsp.bbclass
@@ -67,6 +67,7 @@ IB_ITS_SRC ?= "${IB_DIR}/build/meta-bsp/recipes-bsp/linux/files/its"
 # IB_ITS_SRC/<name>.its into IB_ITB_PATH, expanding the same placeholders.
 # Returns False (a no-op) when IB_ITS_SRC has no <name>.its template, so
 # callers can offer a superset of candidate names and let missing ones skip.
+
 def bsp_render_its_py(d, name):
     import os
     src = os.path.join(d.getVar('IB_ITS_SRC') or '', name + '.its')
@@ -97,6 +98,7 @@ def bsp_render_its_py(d, name):
 # in each do_itb) means adding a platform or variant never needs to re-add
 # render calls; bsp_render_its_py just skips the names that have no template.
 # do_itb then only reads + mkimage's.
+
 python do_render_its() {
     plat       = d.getVar('IB_PLATFORM') or ''
     target_its = d.getVar('IB_TARGET_ITS') or ''

--- a/so3/so3/arch/arm64/head.S
+++ b/so3/so3/arch/arm64/head.S
@@ -64,7 +64,7 @@ __start:
 	str 	x9, [x8]
 
 	// Preserve the agency/guest ITB addr passed in x1 by the bootloader
-	// (e1c-boot / launcher). AVZ loads the agency guest from this separate
+	// (guest-boot / launcher). AVZ loads the agency guest from this separate
 	// ITB (avz_dt stays in the x0 AVZ FIT). Save it now before x1 is
 	// clobbered by el2_setup / bss clear.
 	mov	x10, x1

--- a/so3/so3/avz/kernel/domain_utils.c
+++ b/so3/so3/avz/kernel/domain_utils.c
@@ -177,7 +177,7 @@ void loadAgency(void)
 
 	/* The agency guest (kernel + flat_dt + ramdisk) lives in the separate
 	 * guest ITB (x1). Its loadables are already placed in RAM at their
-	 * declared load addresses by the bootloader (e1c-boot / bootm), so we
+	 * declared load addresses by the bootloader (guest-boot / bootm), so we
 	 * only read their addresses here and point the memslots at them. */
 	nodeoffset = 0;
 	depth = 0;
@@ -293,7 +293,7 @@ void loadAgency(void)
 
 			lprintk("IPA Layout: initrd start at 0x%lx, end at 0x%lx\n", initrd_pa, initrd_end_pa);
 
-			/* Publish into /chosen (already created by e1c-boot with the
+			/* Publish into /chosen (already created by guest-boot with the
 			 * bootargs). Grow the guest flat_dt first to be safe. */
 			fdt_open_into(guest_fdt, guest_fdt, fdt_totalsize(guest_fdt) + 256);
 


### PR DESCRIPTION
Follow-up to #263 (which renamed the U-Boot command `e1c-boot` → `guest-boot` and neutralised its internals).

**1. `avz: finish the … rename in the AVZ boot path`** — two source comments still named the old command: the EL2 entry in `arch/arm64/head.S` (saving the guest ITB addr passed in x1) and `loadAgency()` in `avz/kernel/domain_utils.c` (reading the guest loadables + the `/chosen` bootargs the command published). Updated both to `guest-boot`. Comments only, no behaviour change.

**2. `style: blank line between the comment block and the introduced task`** — house style: a comment block introducing a python def/task gets one blank line before it (`bsp_render_its_py`, `do_render_its` in `bsp.bbclass`).