### PR TITLE
its: refresh the generic virt64 linux ITS to the current structure

### DIFF
--- a/build/meta-bsp/recipes-bsp/linux/files/its/virt64.its
+++ b/build/meta-bsp/recipes-bsp/linux/files/its/virt64.its
@@ -1,5 +1,22 @@
 /*
- * Copyright (C) 2020 Daniel Rossier <daniel.rossier@heig-vd.ch>
+ * Copyright (C) 2020-2026 EDGEMTech SA <info@edgemtech.ch>
+ *
+ * Bare bsp-linux ITS for QEMU virt64. Pairs with IB_BOOT_CHAIN=
+ * "uboot": QEMU loads the U-Boot ELF directly via `-kernel` (no ATF,
+ * no OP-TEE, no AVZ — purest dev path). U-Boot bootm's this ITB; the
+ * buildroot initrd is the rootfs (root=/dev/ram).
+ *
+ * Kernel + DTB: the outer-linux build (arch/arm64/.../${IB_PLATFORM}.dtb,
+ * the customised virt DT — see the virt64.dts patch in meta-linux).
+ * Initrd: linux/rootfs's board/${IB_PLATFORM}/rootfs.cpio (buildroot
+ * output gzipped at deploy time into initrd.cpio.gz).
+ *
+ * Template: ${IB_*_PATH} / ${IB_PLATFORM} placeholders are expanded to
+ * absolute build paths by bsp_render_its (bsp.bbclass) at do_itb time.
+ *
+ * The AVZ two-ITB path uses virt64_avz.its + the guest ITB instead
+ * (virt64_so3_guest.its for bsp-so3, virt64_linux_guest.its for the
+ * Linux agency) — see those files for the guest-boot variant.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 as
@@ -33,35 +50,35 @@
 			load = <0x41000000>;
 			entry = <0x41000000>;
 		};
-	
-        	fdt_linux {
+
+		fdt_linux {
 			description = "Linux device tree blob";
-			data = /incbin/("${IB_LINUX_PATH}/arch/arm64/boot/dts/arm/virt64.dtb");
+			data = /incbin/("${IB_LINUX_PATH}/arch/arm64/boot/dts/arm/${IB_PLATFORM}.dtb");
 			type = "flat_dt";
 			arch = "arm64";
 			compression = "none";
 			load = <0x50000000>;
 		};
-                  
+
 		initrd {
 			description = "Initial rootfs (initrd)";
-			data = /incbin/("${IB_ROOTFS_PATH}/board/virt64/initrd.cpio.gz");
+			data = /incbin/("${IB_ROOTFS_PATH}/board/${IB_PLATFORM}/initrd.cpio.gz");
 			type = "ramdisk";
 			arch = "arm64";
-			os = "linux";			
-			compression = "none";
+			os = "linux";
+			compression = "gzip";
 			load = <0x50c00000>;
 		};
 	};
 
 	configurations {
 		default = "conf_linux";
-                	
+
 		conf_linux {
 			description = "Linux on virt64";
 			kernel = "linux";
-            		fdt = "fdt_linux"; 
-            		ramdisk = "initrd";  
+			fdt = "fdt_linux";
+			ramdisk = "initrd";
 		};
 	};
 

--- a/build/meta-bsp/recipes-bsp/linux/files/its/virt64_avz.its
+++ b/build/meta-bsp/recipes-bsp/linux/files/its/virt64_avz.its
@@ -1,14 +1,30 @@
 /*
- * Copyright (C) 2020-2026 Daniel Rossier <daniel.rossier@heig-vd.ch>
+ * Copyright (C) 2020-2026 EDGEMTech SA <info@edgemtech.ch>
  *
- * AVZ ITB for virt64 (armv8). Carries only the AVZ hypervisor binary
- * (so3.bin) + the AVZ device tree. The guest (SO3) lives in a SEPARATE
- * ITB (virt64_so3_guest.its); both are loaded by U-Boot's guest-boot
- * command, which passes the AVZ FIT in x0 and the guest ITB in x1.
+ * AVZ ITS for QEMU virt64 (armv8). Carries only the AVZ hypervisor
+ * binary (so3.bin) + the AVZ device tree. The guest lives in a SEPARATE
+ * ITB (virt64_so3_guest.its for bsp-so3, virt64_linux_guest.its for the
+ * Linux agency); both are loaded by U-Boot's guest-boot command, which
+ * passes the AVZ FIT in x0 and the guest ITB in x1.
+ *
+ * Template: ${IB_*_PATH} placeholders are expanded to absolute build
+ * paths by bsp_render_its (bsp.bbclass) at do_itb time.
+ *
+ * The bare path uses virt64.its (bsp-linux, IB_BOOT_CHAIN="uboot")
+ * instead — see that file for the single-ITB bootm variant without AVZ.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 as
  * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  */
 


### PR DESCRIPTION
Follow-up to the so3↔edgem1 generic-substrate audit. The core (recipes, guest-boot command, do_render_its machinery, SO3-guest ITS, virt32/rpi4 ITS) is already aligned and so3 is e1c-free; the only generic linux ITS that had drifted were `virt64.its` and `virt64_avz.its`.

Brings them up to the shared structure (EDGEMTech GPL header, `${IB_PLATFORM}` templating, `gzip` initrd, clean tabs, doc paragraph) while keeping **so3 generic** — guest-boot + SO3/Linux-agency guest framing, no e1c/torizon/Factory-Capsule references.

- `virt64_avz.its`: header/doc only, FIT body unchanged.
- `virt64.its`: also flips the `.cpio.gz` initrd to `compression = "gzip"` (validated by mkimage; matches the edgem1 CI-tested bare-linux ITS).

Note: the `verdin-*.its` and `*_torizon.its` linux ITS are **edgem1-only** product extensions — so3 has no verdin/torizon linux BSP (COMPATIBLE_PLATFORM = virt32|virt64|rpi4_64), so nothing dead to remove here.