### PR TITLE
usr: clear the attach manifest on do_clean so clean+build is reliable

### DIFF
--- a/build/meta-usr/classes/usr.bbclass
+++ b/build/meta-usr/classes/usr.bbclass
@@ -127,11 +127,25 @@ addtask do_clean
 # "No such file or directory: .../temp/fifo.NNNN". Python tasks create the
 # temp dir themselves and use no fifo, so they are robust here.
 python do_clean() {
-    import shutil
+    import os, shutil
     target = d.getVar('IB_TARGET')
     # Remove the applied patches and the (in-tree) user-space build dir.
     shutil.rmtree(target + '/patches', ignore_errors=True)
     shutil.rmtree(target + '/build', ignore_errors=True)
+
+    # Clear the do_attach_infrabase manifest (${IB_TARGET}.attach.sha256) so the
+    # next attach re-attaches from a fresh fetch+patch instead of aborting with
+    # "Refusing to re-attach". Generic to every usr recipe: the usr build mutates
+    # IB_TARGET in place (e.g. the :lvgl override fetches lib/lvgl and renames its
+    # stray CMakeLists.txt to hide them from the recursive CMake glob), and those
+    # renames/removals make the manifest's `sha256sum -c` fail on the next attach.
+    # A clean is an explicit reset, and the attach still backs the tree up to
+    # ${IB_TARGET}.back, so dropping the manifest here is the safe, generic fix —
+    # the guard stays fully active for builds that were NOT preceded by a clean.
+    try:
+        os.remove(target + '.attach.sha256')
+    except OSError:
+        pass
 }
 
 


### PR DESCRIPTION
Fixes the recurring `Refusing to re-attach usr-so3` failure on `build.sh -xc bsp-so3` (and any usr recipe) when a build mutates the attached tree in place — notably the `:lvgl` override, which fetches `lib/lvgl` and renames its stray `CMakeLists.txt` to hide them from the recursive CMake glob. Those renames make `do_attach_infrabase`'s `sha256sum -c` report the manifest entries as FAILED on the next attach.

**Generic fix in `meta-usr/classes/usr.bbclass:do_clean`** (not per-recipe): drop `${IB_TARGET}.attach.sha256` on clean so the next attach re-attaches fresh. Safe — a clean is an explicit reset, the attach still keeps `${IB_TARGET}.back`, and the guard stays active for builds not preceded by a clean.

Validated: `build.sh -xc bsp-so3` with `:lvgl` now succeeds on two consecutive runs (previously failed on the 2nd).