### PR TITLE
avz: remove the real-time agency remnants

### DIFF
--- a/build/meta-linux/recipes-linux/soo/files/0001-linux-6.12-r0/0018-Kconfig.patch
+++ b/build/meta-linux/recipes-linux/soo/files/0001-linux-6.12-r0/0018-Kconfig.patch
@@ -9,7 +9,7 @@
 +menu "Smart Object Oriented subsystem" 
 +
 +config VDUMMY_BACKEND
-+        bool "SOO (realtime and no-RT) vDummy support for debugging and testing"
++        bool "SOO vDummy support for debugging and testing"
 +
 +config VUART_BACKEND
 +	bool "vuart UART Backend support for SOO Mobile Entity consoles"

--- a/build/meta-linux/recipes-linux/soo/files/0001-linux-6.12-r0/0033-avz.h.patch
+++ b/build/meta-linux/recipes-linux/soo/files/0001-linux-6.12-r0/0033-avz.h.patch
@@ -1,6 +1,6 @@
 --- /home/rossierd/soo/git/micofe/build/tmp/work/linux-6.12-r0/linux-6.12/soo/include/avz/uapi/avz.h	1970-01-01 01:00:00.000000000 +0100
 +++ ./soo/include/avz/uapi/avz.h	2025-08-29 08:46:41.396291602 +0200
-@@ -0,0 +1,304 @@
+@@ -0,0 +1,300 @@
 +/*
 + * Copyright (C) 2016-2022 Daniel Rossier <daniel.rossier@heig-vd.ch>
 + *
@@ -37,7 +37,6 @@
 +#define NR_VIRQS 256
 +
 +#define VIRQ_TIMER 0 /* System timer tick virtualized interrupt */
-+#define VIRQ_TIMER_RT 1 /* Timer tick issued from the oneshot timer (for RT agency and MEs */
 +
 +/**************************************************/
 +
@@ -55,14 +54,11 @@
 +
 +#define MAX_ME_DOMAINS 5
 +
-+/* We include the (non-RT & RT) agency domain */
++/* domains[]: 0 = agency, 1 = reserved, 2.. = up to MAX_ME_DOMAINS capsules */
 +#define MAX_DOMAINS (2 + MAX_ME_DOMAINS)
 +
 +/* Agency */
 +#define DOMID_AGENCY 0
-+
-+/* Realtime agency subdomain */
-+#define DOMID_AGENCY_RT 1
 +
 +#define DOMID_INVALID (0x7FF4U)
 +

--- a/build/meta-linux/recipes-linux/soo/files/0001-linux-6.12-r0/0060-debug.h.patch
+++ b/build/meta-linux/recipes-linux/soo/files/0001-linux-6.12-r0/0060-debug.h.patch
@@ -1,6 +1,6 @@
 --- /home/rossierd/soo/git/micofe/build/tmp/work/linux-6.12-r0/linux-6.12/soo/include/soo/uapi/debug.h	1970-01-01 01:00:00.000000000 +0100
 +++ ./soo/include/soo/uapi/debug.h	2025-08-29 08:46:41.395937531 +0200
-@@ -0,0 +1,76 @@
+@@ -0,0 +1,75 @@
 +/*
 + * Copyright (C) 2015-2019 Daniel Rossier <daniel.rossier@soo.tech>
 + *
@@ -67,7 +67,6 @@
 +#else
 +
 +#define DBG(fmt, ...)
-+#define RTDBG(fmt, ...)
 +#define DBG0(...)
 +#define DBG_BUFFER(buffer, ...)
 +#define DBG_ON__

--- a/build/meta-linux/recipes-linux/soo/files/0001-linux-6.12-r0/0062-soo.h.patch
+++ b/build/meta-linux/recipes-linux/soo/files/0001-linux-6.12-r0/0062-soo.h.patch
@@ -1,6 +1,6 @@
 --- /home/rossierd/soo/git/micofe/build/tmp/work/linux-6.12-r0/linux-6.12/soo/include/soo/uapi/soo.h	1970-01-01 01:00:00.000000000 +0100
 +++ ./soo/include/soo/uapi/soo.h	2025-08-29 08:46:41.395924678 +0200
-@@ -0,0 +1,462 @@
+@@ -0,0 +1,461 @@
 +/*
 + * Copyright (C) 2014-2025 Daniel Rossier <daniel.rossier@heig-vd.ch>
 + *
@@ -34,7 +34,6 @@
 +#endif /* __ASSEMBLY__ */
 +
 +#define AGENCY_CPU 0
-+#define AGENCY_RT_CPU 1
 +
 +#ifndef __ASSEMBLY__
 +
@@ -203,7 +202,7 @@
 +
 +	uint64_t agencyUID; /* Agency UID */
 +
-+	/* Event channels used for directcomm channel between agency and agency-RT or ME */
++	/* Event channels used for directcomm channel between agency and ME */
 +	unsigned int dc_evtchn[MAX_DOMAINS];
 +
 +	/* Event channels used by vbstore */

--- a/build/meta-linux/recipes-linux/soo/files/0001-linux-6.12-r0/0074-console.c.patch
+++ b/build/meta-linux/recipes-linux/soo/files/0001-linux-6.12-r0/0074-console.c.patch
@@ -79,13 +79,13 @@
 +int avz_switch_console(char ch)
 +{
 +	static int switch_code_count = 0;
-+	static char *input_str[N_SWITCH_FOCUS] = { "Agency domain", "Agency-RT domain", "ME-1(2)", "ME-2(3)", "ME-3(4)", "ME-4(5)", "ME-5(6)", "Agency AVZ Hypervisor" };
++	static char *input_str[N_SWITCH_FOCUS] = { "Agency domain", "reserved", "ME-1(2)", "ME-2(3)", "ME-3(4)", "ME-4(5)", "ME-5(6)", "Agency AVZ Hypervisor" };
 +	struct device_node *np;
 +	int active = 0;
 +	u32 focus_max = N_SWITCH_FOCUS - 1;
 +        avz_hyp_t args;
 +
-+#if 0 /* Interactions with RT domain? */
++#if 0 /* Interactions with reserved domain? */
 +	int next = 1;
 +#endif
 +	int next = 2;
@@ -127,7 +127,7 @@
 +		case 0: /* Input to the agency */
 +			return 0;
 +
-+		case 1: /* RT domain */
++		case 1: /* reserved domain */
 +		case 2: /* Input to ME #1 */
 +		case 3: /* Input to ME #2 */
 +		case 4: /* Input to ME #3 */

--- a/build/meta-linux/recipes-linux/soo/files/0001-linux-6.12-r0/0094-vbus.c.patch
+++ b/build/meta-linux/recipes-linux/soo/files/0001-linux-6.12-r0/0094-vbus.c.patch
@@ -195,7 +195,7 @@
 +
 +/*
 + * The following function is called either in the backend OR the frontend.
-+ * On the backend side, it may run on CPU #0 (non-RT) or CPU #1 if the backend is configured as realtime.
++ * On the backend side, it runs on the agency CPU.
 + */
 +void vbus_otherend_changed(struct vbus_watch *watch) {
 +	struct vbus_device *vdev = container_of(watch, struct vbus_device, otherend_watch);
@@ -317,7 +317,7 @@
 +		 */
 +		vbus_switch_state(vdev, VbusStateInitWait);
 +
-+		/* For both RT and non-RT initialization, we wait that the device gets connected */
++		/* We wait until the device gets connected */
 +		wait_for_completion(&vdev->sync_backfront);
 +	}
 +
@@ -813,8 +813,8 @@
 +
 +	/*
 +	 * Set up the directcomm communication channel that
-+	 * is used between the different domains, mainly between the agency and MEs,
-+	 * or the non-realtime and realtime agency.
++	 * is used between the different domains, mainly between the agency and the
++	 * MEs (capsules).
 +	 */
 +
 +	for (i = 1; i < MAX_DOMAINS; i++) {

--- a/build/meta-linux/recipes-linux/soo/files/0001-linux-6.12-rpi4-r0/0018-Kconfig.patch
+++ b/build/meta-linux/recipes-linux/soo/files/0001-linux-6.12-rpi4-r0/0018-Kconfig.patch
@@ -9,7 +9,7 @@
 +menu "Smart Object Oriented subsystem" 
 +
 +config VDUMMY_BACKEND
-+        bool "SOO (realtime and no-RT) vDummy support for debugging and testing"
++        bool "SOO vDummy support for debugging and testing"
 +
 +config VUART_BACKEND
 +	bool "vuart UART Backend support for SOO Mobile Entity consoles"

--- a/build/meta-linux/recipes-linux/soo/files/0001-linux-6.12-rpi4-r0/0033-avz.h.patch
+++ b/build/meta-linux/recipes-linux/soo/files/0001-linux-6.12-rpi4-r0/0033-avz.h.patch
@@ -1,6 +1,6 @@
 --- /home/rossierd/soo/git/micofe/build/tmp/work/linux-6.12-r0/linux-6.12/soo/include/avz/uapi/avz.h	1970-01-01 01:00:00.000000000 +0100
 +++ ./soo/include/avz/uapi/avz.h	2025-08-29 08:46:41.396291602 +0200
-@@ -0,0 +1,304 @@
+@@ -0,0 +1,300 @@
 +/*
 + * Copyright (C) 2016-2022 Daniel Rossier <daniel.rossier@heig-vd.ch>
 + *
@@ -37,7 +37,6 @@
 +#define NR_VIRQS 256
 +
 +#define VIRQ_TIMER 0 /* System timer tick virtualized interrupt */
-+#define VIRQ_TIMER_RT 1 /* Timer tick issued from the oneshot timer (for RT agency and MEs */
 +
 +/**************************************************/
 +
@@ -55,14 +54,11 @@
 +
 +#define MAX_ME_DOMAINS 5
 +
-+/* We include the (non-RT & RT) agency domain */
++/* domains[]: 0 = agency, 1 = reserved, 2.. = up to MAX_ME_DOMAINS capsules */
 +#define MAX_DOMAINS (2 + MAX_ME_DOMAINS)
 +
 +/* Agency */
 +#define DOMID_AGENCY 0
-+
-+/* Realtime agency subdomain */
-+#define DOMID_AGENCY_RT 1
 +
 +#define DOMID_INVALID (0x7FF4U)
 +

--- a/build/meta-linux/recipes-linux/soo/files/0001-linux-6.12-rpi4-r0/0060-debug.h.patch
+++ b/build/meta-linux/recipes-linux/soo/files/0001-linux-6.12-rpi4-r0/0060-debug.h.patch
@@ -1,6 +1,6 @@
 --- /home/rossierd/soo/git/micofe/build/tmp/work/linux-6.12-r0/linux-6.12/soo/include/soo/uapi/debug.h	1970-01-01 01:00:00.000000000 +0100
 +++ ./soo/include/soo/uapi/debug.h	2025-08-29 08:46:41.395937531 +0200
-@@ -0,0 +1,76 @@
+@@ -0,0 +1,75 @@
 +/*
 + * Copyright (C) 2015-2019 Daniel Rossier <daniel.rossier@soo.tech>
 + *
@@ -67,7 +67,6 @@
 +#else
 +
 +#define DBG(fmt, ...)
-+#define RTDBG(fmt, ...)
 +#define DBG0(...)
 +#define DBG_BUFFER(buffer, ...)
 +#define DBG_ON__

--- a/build/meta-linux/recipes-linux/soo/files/0001-linux-6.12-rpi4-r0/0062-soo.h.patch
+++ b/build/meta-linux/recipes-linux/soo/files/0001-linux-6.12-rpi4-r0/0062-soo.h.patch
@@ -1,6 +1,6 @@
 --- /home/rossierd/soo/git/micofe/build/tmp/work/linux-6.12-r0/linux-6.12/soo/include/soo/uapi/soo.h	1970-01-01 01:00:00.000000000 +0100
 +++ ./soo/include/soo/uapi/soo.h	2025-08-29 08:46:41.395924678 +0200
-@@ -0,0 +1,460 @@
+@@ -0,0 +1,459 @@
 +/*
 + * Copyright (C) 2014-2025 Daniel Rossier <daniel.rossier@heig-vd.ch>
 + *
@@ -34,7 +34,6 @@
 +#endif /* __ASSEMBLY__ */
 +
 +#define AGENCY_CPU 0
-+#define AGENCY_RT_CPU 1
 +
 +#ifndef __ASSEMBLY__
 +
@@ -203,7 +202,7 @@
 +
 +	uint64_t agencyUID; /* Agency UID */
 +
-+	/* Event channels used for directcomm channel between agency and agency-RT or ME */
++	/* Event channels used for directcomm channel between agency and ME */
 +	unsigned int dc_evtchn[MAX_DOMAINS];
 +
 +	/* Event channels used by vbstore */

--- a/build/meta-linux/recipes-linux/soo/files/0001-linux-6.12-rpi4-r0/0074-console.c.patch
+++ b/build/meta-linux/recipes-linux/soo/files/0001-linux-6.12-rpi4-r0/0074-console.c.patch
@@ -79,13 +79,13 @@
 +int avz_switch_console(char ch)
 +{
 +	static int switch_code_count = 0;
-+	static char *input_str[N_SWITCH_FOCUS] = { "Agency domain", "Agency-RT domain", "ME-1(2)", "ME-2(3)", "ME-3(4)", "ME-4(5)", "ME-5(6)", "Agency AVZ Hypervisor" };
++	static char *input_str[N_SWITCH_FOCUS] = { "Agency domain", "reserved", "ME-1(2)", "ME-2(3)", "ME-3(4)", "ME-4(5)", "ME-5(6)", "Agency AVZ Hypervisor" };
 +	struct device_node *np;
 +	int active = 0;
 +	u32 focus_max = N_SWITCH_FOCUS - 1;
 +        avz_hyp_t args;
 +
-+#if 0 /* Interactions with RT domain? */
++#if 0 /* Interactions with reserved domain? */
 +	int next = 1;
 +#endif
 +	int next = 2;
@@ -127,7 +127,7 @@
 +		case 0: /* Input to the agency */
 +			return 0;
 +
-+		case 1: /* RT domain */
++		case 1: /* reserved domain */
 +		case 2: /* Input to ME #1 */
 +		case 3: /* Input to ME #2 */
 +		case 4: /* Input to ME #3 */

--- a/build/meta-linux/recipes-linux/soo/files/0001-linux-6.12-rpi4-r0/0094-vbus.c.patch
+++ b/build/meta-linux/recipes-linux/soo/files/0001-linux-6.12-rpi4-r0/0094-vbus.c.patch
@@ -195,7 +195,7 @@
 +
 +/*
 + * The following function is called either in the backend OR the frontend.
-+ * On the backend side, it may run on CPU #0 (non-RT) or CPU #1 if the backend is configured as realtime.
++ * On the backend side, it runs on the agency CPU.
 + */
 +void vbus_otherend_changed(struct vbus_watch *watch) {
 +	struct vbus_device *vdev = container_of(watch, struct vbus_device, otherend_watch);
@@ -317,7 +317,7 @@
 +		 */
 +		vbus_switch_state(vdev, VbusStateInitWait);
 +
-+		/* For both RT and non-RT initialization, we wait that the device gets connected */
++		/* We wait until the device gets connected */
 +		wait_for_completion(&vdev->sync_backfront);
 +	}
 +
@@ -813,8 +813,8 @@
 +
 +	/*
 +	 * Set up the directcomm communication channel that
-+	 * is used between the different domains, mainly between the agency and MEs,
-+	 * or the non-realtime and realtime agency.
++	 * is used between the different domains, mainly between the agency and the
++	 * MEs (capsules).
 +	 */
 +
 +	for (i = 1; i < MAX_DOMAINS; i++) {

--- a/build/meta-usr/recipes-usr/soo/files/0001-usr-linux-1.0-r0/0002-debug.h.patch
+++ b/build/meta-usr/recipes-usr/soo/files/0001-usr-linux-1.0-r0/0002-debug.h.patch
@@ -1,6 +1,6 @@
 --- /home/rossierd/soo/micofe/build/tmp/work/usr-linux-1.0-r0/usr-linux-1.0/include/core/debug.h	1970-01-01 01:00:00.000000000 +0100
 +++ ./include/core/debug.h	2025-10-10 17:28:33.584702104 +0200
-@@ -0,0 +1,49 @@
+@@ -0,0 +1,48 @@
 +/*
 + * Copyright (C) 2014-2019 Daniel Rossier <daniel.rossier@soo.tech>
 + * Copyright (C) 2018-2019 Baptiste Delporte <bonel@bonel.net>
@@ -41,7 +41,6 @@
 +#else
 +
 +#define DBG(fmt, ...)
-+#define RTDBG(fmt, ...)
 +#define DBG0(...)
 +#define DBG_BUFFER(buffer, ...)
 +#define DBG_ON__

--- a/build/meta-usr/recipes-usr/soo/files/0001-usr-linux-1.0-r0/0011-debug.h.patch
+++ b/build/meta-usr/recipes-usr/soo/files/0001-usr-linux-1.0-r0/0011-debug.h.patch
@@ -1,6 +1,6 @@
 --- /home/rossierd/soo/micofe/build/tmp/work/usr-linux-1.0-r0/usr-linux-1.0/include/soo/debug.h	1970-01-01 01:00:00.000000000 +0100
 +++ ./include/soo/debug.h	2025-10-10 17:28:33.584815499 +0200
-@@ -0,0 +1,49 @@
+@@ -0,0 +1,48 @@
 +/*
 + * Copyright (C) 2014-2019 Daniel Rossier <daniel.rossier@soo.tech>
 + * Copyright (C) 2018-2019 Baptiste Delporte <bonel@bonel.net>
@@ -41,7 +41,6 @@
 +#else
 +
 +#define DBG(fmt, ...)
-+#define RTDBG(fmt, ...)
 +#define DBG0(...)
 +#define DBG_BUFFER(buffer, ...)
 +#define DBG_ON__

--- a/doc/source/avz.rst
+++ b/doc/source/avz.rst
@@ -76,9 +76,9 @@ shared info page and its scheduling metadata. Well-known identifiers
    * - ``DOMID_AGENCY`` (0)
      - the agency guest — Linux, or a plain SO3 (``CONFIG_SOO=n``); owns the
        devices
-   * - slot 1
-     - reserved
-   * - slots 2 …
+   * - domain id 1
+     - reserved (the agency occupies memory slot 1 but keeps domain id 0)
+   * - domain ids 2 …
      - capsule domains
    * - ``MAX_S3C_DOMAINS`` (5)
      - up to five capsules alongside the agency (``MAX_DOMAINS = 2 + 5``)

--- a/so3/so3/arch/arm64/head.S
+++ b/so3/so3/arch/arm64/head.S
@@ -237,8 +237,8 @@ el2_setup:
    	and 	x1, x1, #3
 
 #ifdef CONFIG_SOO
-	cmp 	x1, #AGENCY_RT_CPU
-	bgt 	guest
+	cmp 	x1, #S3C_CPU
+	bge 	guest
 #endif /* CONFIG_SOO */
 
 agency:

--- a/so3/so3/avz/include/avz/debug.h
+++ b/so3/so3/avz/include/avz/debug.h
@@ -42,13 +42,6 @@
 		force_print("%s:%i > " fmt, __FUNCTION__, __LINE__, ##__VA_ARGS__); \
 	} while (0)
 
-/* rtdm_printk() is broken for the time being. Use lprintk() instead.
- * One can safely switch back to rtdm_printk() once the issues are solved. */
-#define RTDBG(fmt, ...)                                                             \
-	do {                                                                        \
-		force_print("%s:%i > " fmt, __FUNCTION__, __LINE__, ##__VA_ARGS__); \
-	} while (0)
-
 #define DBG0(...) DBG("%s", ##__VA_ARGS__)
 
 #define DBG_BUFFER(buffer, ...)                        \
@@ -59,7 +52,6 @@
 #else
 
 #define DBG(fmt, ...)
-#define RTDBG(fmt, ...)
 #define DBG0(...)
 #define DBG_BUFFER(buffer, ...)
 #define DBG_ON__

--- a/so3/so3/avz/include/avz/uapi/avz.h
+++ b/so3/so3/avz/include/avz/uapi/avz.h
@@ -34,7 +34,6 @@
 #define NR_VIRQS 256
 
 #define VIRQ_TIMER 0 /* System timer tick virtualized interrupt */
-#define VIRQ_TIMER_RT 1 /* Timer tick issued from the oneshot timer (for RT agency and MEs */
 
 /**************************************************/
 
@@ -52,7 +51,7 @@
 
 #define MAX_S3C_DOMAINS 5
 
-/* slot 0 = agency, slot 1 reserved, plus up to MAX_S3C_DOMAINS capsules */
+/* domains[]: 0 = agency, 1 = reserved, 2.. = up to MAX_S3C_DOMAINS capsules */
 #define MAX_DOMAINS (2 + MAX_S3C_DOMAINS)
 
 /* Agency */

--- a/so3/so3/avz/kernel/domain.c
+++ b/so3/so3/avz/kernel/domain.c
@@ -45,8 +45,8 @@ static DEFINE_SPINLOCK(domctl_lock);
 
 /*
  * We don't care of the IDLE domain here...
- * In the domain table, the index 0 and 1 are dedicated to the non-RT and RT agency domains.
- * The indexes 1..MAX_DOMAINS are for the MEs. S3C_slotID should correspond to domain ID.
+ * In the domain table, index 0 is the agency domain; index 1 is reserved and
+ * indexes 2..MAX_DOMAINS are for the capsules. S3C_slotID corresponds to the domain ID.
  */
 struct domain *domains[MAX_DOMAINS];
 
@@ -120,10 +120,7 @@ struct domain *domain_create(domid_t domid, int cpu_id)
 		} else if (cpu_id == AGENCY_CPU) {
 			d->sched = &sched_agency;
 			d->need_periodic_timer = true;
-
-		} else if (cpu_id == AGENCY_RT_CPU)
-
-			d->sched = &sched_agency;
+		}
 	}
 
 	if (sched_init_domain(d, cpu_id) != 0)

--- a/so3/so3/avz/mm/memory.c
+++ b/so3/so3/avz/mm/memory.c
@@ -37,7 +37,7 @@
 
 /*
  * Set of memslots in the RAM memory (do not confuse with memchunk !)
- * In the memslot table, the index 0 is for AVZ, the index 1 is for the two agency domains (domain 0 (non-RT) and domain 1 (RT))
+ * In the memslot table, the index 0 is for AVZ, the index 1 is for the agency domain (domain 0)
  * and the indexes 2..MEMSLOT_NR are for the MEs. If the S3C_slotID is provided, the index is given by S3C_slotID.
  * Hence, the S3C_slotID matches with the capsule domID.
  */

--- a/so3/so3/include/common.h
+++ b/so3/so3/include/common.h
@@ -33,14 +33,12 @@
 #ifdef CONFIG_AVZ
 
 /*
- * CPU #0 is the primary (non-RT) Agency CPU.
- * CPU #1 is the hard RT Agency CPU.
- * CPU #2 is the second (SMP) Agency CPU.
+ * CPU #0 is the primary Agency CPU.
+ * CPU #1 and #2 are additional (SMP) Agency CPUs.
  * CPU #3 is the capsule CPU.
  */
 
 #define AGENCY_CPU 0
-#define AGENCY_RT_CPU 1
 
 #define S3C_CPU 3
 

--- a/so3/so3/soo/include/soo/debug.h
+++ b/so3/so3/soo/include/soo/debug.h
@@ -32,13 +32,6 @@
 		force_print("%s:%i > " fmt, __FUNCTION__, __LINE__, ##__VA_ARGS__); \
 	} while (0)
 
-/* rtdm_printk() is broken for the time being. Use lprintk() instead.
- * One can safely switch back to rtdm_printk() once the issues are solved. */
-#define RTDBG(fmt, ...)                                                             \
-	do {                                                                        \
-		force_print("%s:%i > " fmt, __FUNCTION__, __LINE__, ##__VA_ARGS__); \
-	} while (0)
-
 #define DBG0(...) DBG("%s", ##__VA_ARGS__)
 
 #define DBG_BUFFER(buffer, ...)                        \
@@ -49,7 +42,6 @@
 #else /* DEBUG */
 
 #define DBG(fmt, ...)
-#define RTDBG(fmt, ...)
 #define DBG0(...)
 #define DBG_BUFFER(buffer, ...)
 #define DBG_ON__

--- a/so3/so3/soo/include/soo/uapi/soo.h
+++ b/so3/so3/soo/include/soo/uapi/soo.h
@@ -31,7 +31,6 @@
 #endif /* __ASSEMBLY__ */
 
 #define AGENCY_CPU 0
-#define AGENCY_RT_CPU 1
 
 #ifndef __ASSEMBLY__
 
@@ -214,7 +213,7 @@ typedef struct {
 
 	uint64_t agencyUID; /* Agency UID */
 
-	/* Event channels used for directcomm channel between agency and agency-RT or capsule */
+	/* Event channels used for directcomm channel between agency and capsule */
 	unsigned int dc_evtchn[MAX_DOMAINS];
 
 	/* Event channels used by vbstore */

--- a/so3/so3/soo/include/soo/vbus.h
+++ b/so3/so3/soo/include/soo/vbus.h
@@ -88,8 +88,6 @@ struct vbus_device {
 	struct completion sync_backfront;
 
 	int resuming;
-
-	bool realtime; /* Tell if this device is a RT device */
 };
 
 /* A vbus driver. */
@@ -206,7 +204,6 @@ void vbus_bind_evtchn(struct vbus_device *dev, uint32_t remote_port, uint32_t *p
 void vbus_free_evtchn(struct vbus_device *dev, uint32_t port);
 
 enum vbus_state vbus_read_driver_state(const char *path);
-bool vbus_read_driver_realtime(const char *path);
 
 const char *vbus_strstate(enum vbus_state state);
 int vbus_dev_is_online(struct vbus_device *dev);

--- a/so3/so3/soo/kernel/debug/time.c
+++ b/so3/so3/soo/kernel/debug/time.c
@@ -20,8 +20,7 @@
 /*
  * Timestamp and delay measurement facility.
  *
- * There are two sets of functions: one for a non RT domain (non RT agency or capsule), one for the
- * RT agency. The RT version is prefixed with rtdm_.
+ * These functions are usable from any domain (agency or capsule).
  *
  * Typical usage:
  *

--- a/so3/so3/soo/kernel/soo_guest_activity.c
+++ b/so3/so3/soo/kernel/soo_guest_activity.c
@@ -64,9 +64,7 @@ void dc_stable(int dc_event)
  * Sends a ping event to a remote domain in order to get synchronized.
  * Various types of event (dc_event) can be sent.
  *
- * To perform a ping from the RT domain, please use rtdm_do_sync_agency() in rtdm_vbus.c
- *
- * As for the domain table, the index 0 and 1 are for the agency and the indexes 2..MAX_DOMAINS
+ * As for the domain table, index 0 is the agency, index 1 is reserved and indexes 2..MAX_DOMAINS
  * are for the MEs. If a S3C_slotID is provided, the proper index is given by S3C_slotID.
  *
  * @domID: the target domain

--- a/so3/so3/soo/kernel/vbstore/vbstore_capsule.c
+++ b/so3/so3/soo/kernel/vbstore/vbstore_capsule.c
@@ -50,10 +50,8 @@ static void vbs_s3c_write(const char *dir, const char *node, const char *string)
 /*
  * The following vbstore node creation does not require to be within a transaction
  * since the backend has no visibility on these nodes until it gets the DC_TRIGGER_DEV_PROBE event.
- *
- * <realtime> tells if the device is realtime.
  */
-static void vbstore_dev_init(unsigned int domID, const char *devname, bool realtime, const char *compat)
+static void vbstore_dev_init(unsigned int domID, const char *devname, const char *compat)
 {
 	char rootname[VBS_KEY_LENGTH]; /* Root name depending on domID */
 	char propname[VBS_KEY_LENGTH]; /* Property name depending on domID */
@@ -94,15 +92,6 @@ static void vbstore_dev_init(unsigned int domID, const char *devname, bool realt
 	sprintf(rootname, devrootname, domID);
 	vbs_s3c_write(rootname, "state", "1"); /* = VBusStateInitialising */
 
-	switch (realtime) {
-	case true:
-		vbs_s3c_write(rootname, "realtime", "1");
-		break;
-
-	case false:
-		vbs_s3c_write(rootname, "realtime", "0");
-	}
-
 	vbs_s3c_write(rootname, "backend-id", "0");
 
 	strcpy(devrootname, "backend/");
@@ -128,21 +117,6 @@ static void vbstore_dev_init(unsigned int domID, const char *devname, bool realt
 	strcat(devrootname, "/0"); /* "/backend/vuart/%d/state/1" */
 	sprintf(rootname, devrootname, domID);
 	vbs_s3c_write(rootname, "state", "1");
-
-	switch (realtime) {
-	case true:
-		vbs_s3c_write(rootname, "realtime", "1");
-
-		/* The two next entries are used to synchronize RT and non-RT vbus/vbstore. */
-		vbs_s3c_write(rootname, "sync_backfront", "0");
-
-		vbs_s3c_write(rootname, "sync_backfront_rt", "0");
-
-		break;
-
-	case false:
-		vbs_s3c_write(rootname, "realtime", "0");
-	}
 
 	strcpy(devrootname, "device/%d/");
 	strcat(devrootname, devname);
@@ -273,49 +247,49 @@ void vbstore_devices_populate(void)
 	fdt_node = fdt_find_compatible_node(__fdt_addr, "vdummy,frontend");
 	if (fdt_device_is_available(__fdt_addr, fdt_node)) {
 		DBG("%s: init vdummy...\n", __func__);
-		vbstore_dev_init(S3C_domID(), "vdummy", false, "vdummy,frontend");
+		vbstore_dev_init(S3C_domID(), "vdummy", "vdummy,frontend");
 	}
 
 	fdt_node = fdt_find_compatible_node(__fdt_addr, "vuihandler,frontend");
 	if (fdt_device_is_available(__fdt_addr, fdt_node)) {
 		DBG("%s: Init vUIHandler...\n", __func__);
-		vbstore_dev_init(S3C_domID(), "vuihandler", false, "vuihandler,frontend");
+		vbstore_dev_init(S3C_domID(), "vuihandler", "vuihandler,frontend");
 	}
 
 	fdt_node = fdt_find_compatible_node(__fdt_addr, "vuart,frontend");
 	if (fdt_device_is_available(__fdt_addr, fdt_node)) {
 		DBG("%s: init vuart...\n", __func__);
-		vbstore_dev_init(S3C_domID(), "vuart", false, "vuart,frontend");
+		vbstore_dev_init(S3C_domID(), "vuart", "vuart,frontend");
 	}
 
 	fdt_node = fdt_find_compatible_node(__fdt_addr, "vsenseled,frontend");
 	if (fdt_device_is_available(__fdt_addr, fdt_node)) {
 		DBG("%s: init vsenseled...\n", __func__);
-		vbstore_dev_init(S3C_domID(), "vsenseled", false, "vsenseled,frontend");
+		vbstore_dev_init(S3C_domID(), "vsenseled", "vsenseled,frontend");
 	}
 
 	fdt_node = fdt_find_compatible_node(__fdt_addr, "vsensej,frontend");
 	if (fdt_device_is_available(__fdt_addr, fdt_node)) {
 		DBG("%s: init vsensej...\n", __func__);
-		vbstore_dev_init(S3C_domID(), "vsensej", false, "vsensej,frontend");
+		vbstore_dev_init(S3C_domID(), "vsensej", "vsensej,frontend");
 	}
 
 	fdt_node = fdt_find_compatible_node(__fdt_addr, "vlogs,frontend");
 	if (fdt_device_is_available(__fdt_addr, fdt_node)) {
 		DBG("%s: init vlogs...\n", __func__);
-		vbstore_dev_init(S3C_domID(), "vlogs", false, "vlogs,frontend");
+		vbstore_dev_init(S3C_domID(), "vlogs", "vlogs,frontend");
 	}
 
 	fdt_node = fdt_find_compatible_node(__fdt_addr, "vfbdev,frontend");
 	if (fdt_device_is_available(__fdt_addr, fdt_node)) {
 		DBG("%s: init vfbdev...\n", __func__);
-		vbstore_dev_init(S3C_domID(), "vfbdev", false, "vfbdev,frontend");
+		vbstore_dev_init(S3C_domID(), "vfbdev", "vfbdev,frontend");
 	}
 
 	fdt_node = fdt_find_compatible_node(__fdt_addr, "vinput,frontend");
 	if (fdt_device_is_available(__fdt_addr, fdt_node)) {
 		DBG("%s: init vinput...\n", __func__);
-		vbstore_dev_init(S3C_domID(), "vinput", false, "vinput,frontend");
+		vbstore_dev_init(S3C_domID(), "vinput", "vinput,frontend");
 	}
 }
 

--- a/so3/so3/soo/kernel/vbus/vbus.c
+++ b/so3/so3/soo/kernel/vbus/vbus.c
@@ -163,7 +163,6 @@ void vbus_read_otherend_details(struct vbus_device *vdev, char *id_node, char *p
 }
 /*
  * The following function is called either in the backend OR the frontend.
- * On the backend side, it may run on CPU #0 (non-RT) or CPU #1 if the backend is configured as realtime.
  */
 void vbus_otherend_changed(struct vbus_watch *watch)
 {
@@ -364,10 +363,8 @@ static struct vbus_device *vbus_probe_node(struct vbus_type *bus, const char *ty
 	int err;
 	struct vbus_device *vdev;
 	enum vbus_state state;
-	bool realtime;
 
 	state = vbus_read_driver_state(nodename);
-	realtime = vbus_read_driver_realtime(nodename);
 
 	/* If the backend driver entry exists, but no frontend is using it, there is no
 	 * vbstore entry related to the state and we simply skip it.
@@ -385,7 +382,6 @@ static struct vbus_device *vbus_probe_node(struct vbus_type *bus, const char *ty
 	vdev->state = VbusStateInitialising;
 
 	vdev->resuming = 0;
-	vdev->realtime = realtime;
 
 	vdev->vdrv = NULL;
 	vdev->vbus = bus;
@@ -563,7 +559,7 @@ void vbus_init(void)
 	}
 
 	avz_shared->dom_desc.u.S3C.dc_evtchn = evtchn_from_irq(res);
-	DBG("%s: local event channel bound to directcomm towards non-RT Agency : %d\n", __func__,
+	DBG("%s: local event channel bound to directcomm towards Agency : %d\n", __func__,
 	    avz_shared->dom_desc.u.S3C.dc_evtchn);
 
 	DBG("vbus_init OK!\n");

--- a/so3/so3/soo/kernel/vbus/vbus_client.c
+++ b/so3/so3/soo/kernel/vbus/vbus_client.c
@@ -197,18 +197,3 @@ enum vbus_state vbus_read_driver_state(const char *path)
 
 	return result;
 }
-
-/**
- * vbus_read_driver_realtime
- * @path: path for driver
- *
- * Return the value to indicate if the driver is realtime or not.
- */
-bool vbus_read_driver_realtime(const char *path)
-{
-	int val;
-
-	vbus_gather(VBT_NIL, path, "realtime", "%d", &val, NULL);
-
-	return val;
-}

--- a/so3/so3/soo/kernel/vbus/vbus_frontend.c
+++ b/so3/so3/soo/kernel/vbus/vbus_frontend.c
@@ -132,7 +132,7 @@ void device_shutdown(void)
 }
 
 /*
- * In frontend drivers, otherend_id refering to the agency or *realtime* agency is equal to 0.
+ * In frontend drivers, otherend_id refering to the agency is equal to 0.
  */
 static void read_backend_details(struct vbus_device *vdev)
 {


### PR DESCRIPTION
## Summary

AVZ boots a single agency guest, so the remaining real-time agency machinery is dead weight. This extends the earlier `DOMID_AGENCY_RT` removal by dropping everything else tied to the RT agency, and brings the comments, guest-side patch mirrors and documentation in line.

## Changes

- **`AGENCY_RT_CPU`** (CPU #1) — removed from `common.h` / `soo.h`; dead scheduler branch dropped in `domain.c`; the boot-time HCR-flag split in `head.S` now keys on `S3C_CPU` (agency CPUs sit below the capsule CPU) instead of `AGENCY_RT_CPU`.
- **`VIRQ_TIMER_RT`** — unused VIRQ, removed from `avz.h`.
- **`RTDBG`** — unused debug macro, removed from the `avz` / `soo` `debug.h` headers.
- **`realtime` vbus/vbstore device flag** — vestigial (every device was created non-RT and `vbus_device.realtime` was write-only). Removes the field, `vbus_read_driver_realtime()`, the `"realtime"` / `sync_backfront_rt` vbstore nodes, and the `bool` argument threaded through `vbstore_dev_init()`.
- Refreshed the now-stale RT-agency comments, the guest-Linux and `usr` SOO patch mirrors (hunk counts re-verified), and the AVZ docs — dropped the `"slot 1 reserved"` / RT wording and disambiguated **domain id** vs **memory slot**.

## Testing

- `virt64_avz_soo_defconfig` (AVZ + agency) — builds clean.
- `virt64_capsule_defconfig` (SO3 capsule; actually compiles the vbus / vbstore changes) — builds clean.
