### PR TITLE
conf: default virt64 SO3 build to virt64_fb_defconfig for LVGL

### DIFF
--- a/build/conf/local.conf
+++ b/build/conf/local.conf
@@ -10,6 +10,127 @@ IB_PLATFORM ?= "virt64"
 # IB_PLATFORM ?= "verdin-imx8mp"
 
 # ============================================================================
+#                                   SO3
+# ============================================================================
+# SO3 builds in one of three contexts, all on the current IB_PLATFORM (there is
+# intentionally NO IB_PLATFORM:so3 override — a divergent one used to silently
+# build SO3 for the wrong arch). What selects the context is the CONFIG and the
+# ITS below, not the platform:
+#
+#   standalone   SO3 alone, bare metal at EL1.          ITS = virt64_so3
+#   guest        SO3 as a guest on the AVZ hypervisor.  ITS = virt64_avz
+#                Two-ITB boot: the AVZ ITB (virt64_avz.its = hypervisor +
+#                avz_dt) and the SO3 guest ITB (auto-derived virt64_so3_guest.its)
+#                are loaded together by U-Boot's guest-boot command. Requires the
+#                AVZ config + version from the AVZ section below.
+#                Build: select the ITS here, then `build.sh -x avz`, then deploy
+#                bsp-so3 (do_itb mkimage's both ITBs; usr-so3 fills the guest
+#                rootfs.fat).
+#   capsule      SO3 as a migratable capsule.           ITS = virt64_capsule
+
+# --- Versions ---
+PREFERRED_VERSION_so3:virt32  = "6.2.0"
+PREFERRED_VERSION_so3:virt64  = "6.2.0"
+PREFERRED_VERSION_so3:rpi4_64 = "6.2.0"
+
+# --- Configs (kernel defconfig) ---
+# standalone and guest share the plain defconfig; capsule has its own.
+# IB_CONFIG:so3:virt64  ?= "virt64_defconfig"
+# IB_CONFIG:so3:virt64  ?= "virt64_capsule_defconfig"
+# IB_CONFIG:so3:virt64  ?= "virt64_lvperf_defconfig"
+IB_CONFIG:so3:virt64  ?= "virt64_fb_defconfig"
+IB_CONFIG:so3:virt32  ?= "virt32_fb_defconfig"
+IB_CONFIG:so3:rpi4_64 ?= "rpi4_64_defconfig"
+
+# --- ITS (boot-image selection) ---
+# virt64: pick exactly ONE of standalone / guest / capsule.
+# standalone (EL1, bare metal):
+IB_TARGET_ITS:so3:virt64    = "virt64_so3"
+# guest on AVZ (auto-derives virt64_so3_guest):
+# IB_TARGET_ITS:so3:virt64  = "virt64_avz"
+# capsule:
+# IB_TARGET_ITS:so3:virt64  = "virt64_capsule"
+IB_TARGET_ITS:so3:virt32   ?= "virt32_so3"
+# rpi4_64 standalone:
+IB_TARGET_ITS:so3:rpi4_64  ?= "rpi4_64_so3"
+# rpi4_64 guest on AVZ (two-ITB):
+# IB_TARGET_ITS:so3:rpi4_64 ?= "rpi4_64_avz"
+
+# ============================================================================
+#                                   AVZ
+# ============================================================================
+# AVZ hypervisor — used by the SO3 "guest" context above (and by capsules).
+# The AVZ ITB itself is selected through IB_TARGET_ITS:so3 = "<plat>_avz" in
+# the SO3 section; here we set only the hypervisor version and build config.
+
+# --- Versions ---
+PREFERRED_VERSION_avz:virt64        = "6.2.0"
+PREFERRED_VERSION_avz:verdin-imx8mp = "6.2.0"
+
+# --- Configs ---
+# virt64_avz_soo_defconfig (CONFIG_SOO=y) is required when AVZ hosts a guest that
+# uses the SOO services (vbstore, capsule mgmt) — i.e. the Linux/SO3 agency. Use
+# virt64_avz_defconfig only for a plain SO3 guest with no SOO hypercalls.
+# IB_CONFIG:avz:virt64      ?= "virt64_avz_defconfig"
+IB_CONFIG:avz:virt64        ?= "virt64_avz_soo_defconfig"
+IB_CONFIG:avz:verdin-imx8mp ?= "verdin-imx8mp_avz_defconfig"
+
+# *************** Boot chain ***************
+#
+# IB_BOOT_CHAIN selects how the platform firmware is brought up. It is set
+# here as the SO3 default; a capsule layer may override it (edgem1 model:
+# the e1c capsule sets it to "full"). Hence "?=" (weak) so the override
+# wins. Values:
+#   ""           bare U-Boot (virt64_defconfig), no ATF. SO3 standalone (EL1)
+#                and SO3-on-AVZ without ATF — st.sh enables QEMU EL2
+#                (virtualization=on) when the avz ITS is selected. SO3 default.
+#   "uboot"      bare U-Boot, qemu_arm64_defconfig (EL1, position-independent):
+#                the bare-Linux variant (kept for edgem1 alignment).
+#   "atf+uboot"  ATF in flash0.img (BL1 + FIP[BL2+BL31+U-Boot]), no OP-TEE.
+#   "full"       ATF + OP-TEE (BL32) + U-Boot in flash0.img — secure world.
+# The flash0.img assembly lives in meta-bsp/.../bsp_virt64.inc
+# (__do_platform_boot_chain); st.sh picks ATF vs bare from its presence.
+
+IB_BOOT_CHAIN ?= ""
+
+# ATF / OP-TEE platform identifiers for QEMU virt (used when IB_BOOT_CHAIN
+# is "atf+uboot" or "full"). Mirrors edgem1's virt64 settings.
+
+IB_ATF_PLAT:virt64 = "qemu"
+IB_OPTEE_PLAT:virt64 = "vexpress-qemu_armv8a"
+IB_ATF_EXTRA_OPTS:virt64 = "${@bb.utils.contains('IB_BOOT_CHAIN', 'full', 'SPD=opteed ', '', d)}LOG_LEVEL=40"
+
+# *************** Verdin iMX8MP (SO3 guest on AVZ) ***************
+# SO3 runs as an AVZ guest on the Toradex Verdin iMX8MP. The firmware chain is
+# always ATF (EL3) + OP-TEE + U-Boot (the imx-boot/flash.bin), independent of
+# Torizon and the e1c capsules. Select the board with IB_PLATFORM="verdin-imx8mp".
+# AVZ + bundled u-boot + the imx8mp ATF/OP-TEE settings mirror edgem1's verdin
+# build; the SO3 guest replaces the Linux guest. Two-ITB boot like virt64: the
+# AVZ ITB (verdin_imx8mp_avz.its) and the SO3 guest ITB
+# (verdin_imx8mp_so3_guest.its), loaded by U-Boot's guest-boot command.
+# SO3 as an AVZ guest (default). For SO3 standalone (bare-metal, no AVZ) select
+# the standalone config + ITS, and build U-Boot with the EL1 switch so it hands
+# SO3 off at EL1 (SO3 standalone is EL1-native; AVZ instead needs EL2):
+#   IB_CONFIG:so3:verdin-imx8mp     ?= "verdin-imx8mp_defconfig"
+#   IB_TARGET_ITS:so3:verdin-imx8mp ?= "verdin_imx8mp_so3"
+#   IB_UBOOT_SWITCH_EL1 = "1"
+
+IB_CONFIG:so3:verdin-imx8mp ?= "verdin-imx8mp_avz_defconfig"
+IB_TARGET_ITS:so3:verdin-imx8mp ?= "verdin_imx8mp_avz"
+
+# NOTE: the virt64 SO3 ITS is set once, in the SO3 section above — do not
+# re-assign IB_TARGET_ITS:so3:virt64 here (a stray "= virt64_avz" used to live
+# at this spot and silently overrode the SO3 section).
+
+# imx-boot's U-Boot hands the OS off at EL2 by default (AVZ). Set to "1" for the
+# standalone variant so U-Boot switches to EL1 first (CONFIG_ARMV8_SWITCH_TO_EL1).
+IB_UBOOT_SWITCH_EL1 ?= "0"
+
+PREFERRED_VERSION_avz:verdin-imx8mp = "6.2.0"
+IB_CONFIG:avz:verdin-imx8mp ?= "verdin-imx8mp_avz_defconfig"
+
+
+# ============================================================================
 #                                  LINUX
 # ============================================================================
 # Like SO3, Linux builds in several contexts on the current IB_PLATFORM,
@@ -29,6 +150,7 @@ PREFERRED_VERSION_linux = "${PREFERRED_VERSION_linux:${IB_PLATFORM}}"
 
 # --- Configs (kernel defconfig) ---
 # agency for SO3 capsules (use virt64_defconfig for a plain Linux guest):
+
 # IB_CONFIG:linux:virt64        ?= "virt64_defconfig"
 IB_CONFIG:linux:virt64        ?= "virt64_soo_defconfig"
 # IB_CONFIG:linux:rpi4_64       ?= "rpi4_64_defconfig"
@@ -38,6 +160,7 @@ IB_CONFIG:linux:verdin-imx8mp ?= "verdin_imx8mp_defconfig"
 # --- ITS (boot-image selection) ---
 # Linux alone:
 # IB_TARGET_ITS:linux:virt64    ?= "virt64"
+
 # Linux as a guest on AVZ:
 IB_TARGET_ITS:linux:virt64  ?= "virt64_avz"
 
@@ -79,122 +202,6 @@ PREFERRED_VERSION_uboot:verdin-imx8mp = "2024.07"
 PREFERRED_VERSION_usr-linux:virt64  = "1.0"
 PREFERRED_VERSION_usr-linux:rpi4_64 = "1.0"
 
-# ============================================================================
-#                                   SO3
-# ============================================================================
-# SO3 builds in one of three contexts, all on the current IB_PLATFORM (there is
-# intentionally NO IB_PLATFORM:so3 override — a divergent one used to silently
-# build SO3 for the wrong arch). What selects the context is the CONFIG and the
-# ITS below, not the platform:
-#
-#   standalone   SO3 alone, bare metal at EL1.          ITS = virt64_so3
-#   guest        SO3 as a guest on the AVZ hypervisor.  ITS = virt64_avz
-#                Two-ITB boot: the AVZ ITB (virt64_avz.its = hypervisor +
-#                avz_dt) and the SO3 guest ITB (auto-derived virt64_so3_guest.its)
-#                are loaded together by U-Boot's guest-boot command. Requires the
-#                AVZ config + version from the AVZ section below.
-#                Build: select the ITS here, then `build.sh -x avz`, then deploy
-#                bsp-so3 (do_itb mkimage's both ITBs; usr-so3 fills the guest
-#                rootfs.fat).
-#   capsule      SO3 as a migratable capsule.           ITS = virt64_capsule
-
-# --- Versions ---
-PREFERRED_VERSION_so3:virt32  = "6.2.0"
-PREFERRED_VERSION_so3:virt64  = "6.2.0"
-PREFERRED_VERSION_so3:rpi4_64 = "6.2.0"
-
-# --- Configs (kernel defconfig) ---
-# standalone and guest share the plain defconfig; capsule has its own.
-IB_CONFIG:so3:virt64  ?= "virt64_defconfig"
-# IB_CONFIG:so3:virt64  ?= "virt64_capsule_defconfig"
-# IB_CONFIG:so3:virt64  ?= "virt64_lvperf_defconfig"
-# IB_CONFIG:so3:virt64  ?= "virt64_fb_defconfig"
-IB_CONFIG:so3:virt32  ?= "virt32_fb_defconfig"
-IB_CONFIG:so3:rpi4_64 ?= "rpi4_64_defconfig"
-
-# --- ITS (boot-image selection) ---
-# virt64: pick exactly ONE of standalone / guest / capsule.
-# standalone (EL1, bare metal):
-IB_TARGET_ITS:so3:virt64    = "virt64_so3"
-# guest on AVZ (auto-derives virt64_so3_guest):
-# IB_TARGET_ITS:so3:virt64  = "virt64_avz"
-# capsule:
-# IB_TARGET_ITS:so3:virt64  = "virt64_capsule"
-IB_TARGET_ITS:so3:virt32   ?= "virt32_so3"
-# rpi4_64 standalone:
-IB_TARGET_ITS:so3:rpi4_64  ?= "rpi4_64_so3"
-# rpi4_64 guest on AVZ (two-ITB):
-# IB_TARGET_ITS:so3:rpi4_64 ?= "rpi4_64_avz"
-
- 
-# ============================================================================
-#                                   AVZ
-# ============================================================================
-# AVZ hypervisor — used by the SO3 "guest" context above (and by capsules).
-# The AVZ ITB itself is selected through IB_TARGET_ITS:so3 = "<plat>_avz" in
-# the SO3 section; here we set only the hypervisor version and build config.
-
-# --- Versions ---
-PREFERRED_VERSION_avz:virt64        = "6.2.0"
-PREFERRED_VERSION_avz:verdin-imx8mp = "6.2.0"
-
-# --- Configs ---
-# virt64_avz_soo_defconfig (CONFIG_SOO=y) is required when AVZ hosts a guest that
-# uses the SOO services (vbstore, capsule mgmt) — i.e. the Linux/SO3 agency. Use
-# virt64_avz_defconfig only for a plain SO3 guest with no SOO hypercalls.
-# IB_CONFIG:avz:virt64      ?= "virt64_avz_defconfig"
-IB_CONFIG:avz:virt64        ?= "virt64_avz_soo_defconfig"
-IB_CONFIG:avz:verdin-imx8mp ?= "verdin-imx8mp_avz_defconfig"
-
-# *************** Boot chain ***************
-#
-# IB_BOOT_CHAIN selects how the platform firmware is brought up. It is set
-# here as the SO3 default; a capsule layer may override it (edgem1 model:
-# the e1c capsule sets it to "full"). Hence "?=" (weak) so the override
-# wins. Values:
-#   ""           bare U-Boot (virt64_defconfig), no ATF. SO3 standalone (EL1)
-#                and SO3-on-AVZ without ATF — st.sh enables QEMU EL2
-#                (virtualization=on) when the avz ITS is selected. SO3 default.
-#   "uboot"      bare U-Boot, qemu_arm64_defconfig (EL1, position-independent):
-#                the bare-Linux variant (kept for edgem1 alignment).
-#   "atf+uboot"  ATF in flash0.img (BL1 + FIP[BL2+BL31+U-Boot]), no OP-TEE.
-#   "full"       ATF + OP-TEE (BL32) + U-Boot in flash0.img — secure world.
-# The flash0.img assembly lives in meta-bsp/.../bsp_virt64.inc
-# (__do_platform_boot_chain); st.sh picks ATF vs bare from its presence.
-IB_BOOT_CHAIN ?= ""
-
-# ATF / OP-TEE platform identifiers for QEMU virt (used when IB_BOOT_CHAIN
-# is "atf+uboot" or "full"). Mirrors edgem1's virt64 settings.
-IB_ATF_PLAT:virt64 = "qemu"
-IB_OPTEE_PLAT:virt64 = "vexpress-qemu_armv8a"
-IB_ATF_EXTRA_OPTS:virt64 = "${@bb.utils.contains('IB_BOOT_CHAIN', 'full', 'SPD=opteed ', '', d)}LOG_LEVEL=40"
-
-# *************** Verdin iMX8MP (SO3 guest on AVZ) ***************
-# SO3 runs as an AVZ guest on the Toradex Verdin iMX8MP. The firmware chain is
-# always ATF (EL3) + OP-TEE + U-Boot (the imx-boot/flash.bin), independent of
-# Torizon and the e1c capsules. Select the board with IB_PLATFORM="verdin-imx8mp".
-# AVZ + bundled u-boot + the imx8mp ATF/OP-TEE settings mirror edgem1's verdin
-# build; the SO3 guest replaces the Linux guest. Two-ITB boot like virt64: the
-# AVZ ITB (verdin_imx8mp_avz.its) and the SO3 guest ITB
-# (verdin_imx8mp_so3_guest.its), loaded by U-Boot's guest-boot command.
-# SO3 as an AVZ guest (default). For SO3 standalone (bare-metal, no AVZ) select
-# the standalone config + ITS, and build U-Boot with the EL1 switch so it hands
-# SO3 off at EL1 (SO3 standalone is EL1-native; AVZ instead needs EL2):
-#   IB_CONFIG:so3:verdin-imx8mp     ?= "verdin-imx8mp_defconfig"
-#   IB_TARGET_ITS:so3:verdin-imx8mp ?= "verdin_imx8mp_so3"
-#   IB_UBOOT_SWITCH_EL1 = "1"
-IB_CONFIG:so3:verdin-imx8mp ?= "verdin-imx8mp_avz_defconfig"
-IB_TARGET_ITS:so3:verdin-imx8mp ?= "verdin_imx8mp_avz"
-# NOTE: the virt64 SO3 ITS is set once, in the SO3 section above — do not
-# re-assign IB_TARGET_ITS:so3:virt64 here (a stray "= virt64_avz" used to live
-# at this spot and silently overrode the SO3 section).
-
-# imx-boot's U-Boot hands the OS off at EL2 by default (AVZ). Set to "1" for the
-# standalone variant so U-Boot switches to EL1 first (CONFIG_ARMV8_SWITCH_TO_EL1).
-IB_UBOOT_SWITCH_EL1 ?= "0"
-
-PREFERRED_VERSION_avz:verdin-imx8mp = "6.2.0"
-IB_CONFIG:avz:verdin-imx8mp ?= "verdin-imx8mp_avz_defconfig"
 
 # Verdin U-Boot 2024.07 assembles imx-boot/flash.bin (SPL + ATF + OP-TEE + U-Boot).
 PREFERRED_VERSION_uboot:verdin-imx8mp = "2024.07"
@@ -277,9 +284,9 @@ BB_NO_NETWORK_SANDBOX = "1"
 BB_WARN_ONLY = "true"
 
 # EXTRA_OVERRIDES enables fine-grained customization for the various IB recipes.
-EXTRA_OVERRIDES .= ":soo"
+# EXTRA_OVERRIDES .= ":soo"
 # :lvgl activates the lvgl bbappend which FETCHES lvgl (release/v9.3) into
 # usr/lib/lvgl at build time  
-# EXTRA_OVERRIDES .= ":lvgl"
+EXTRA_OVERRIDES .= ":lvgl"
 # EXTRA_OVERRIDES .= ":lvgl:soo"
 


### PR DESCRIPTION
## Summary
Make `virt64_fb_defconfig` the active `IB_CONFIG:so3:virt64` (previously `virt64_defconfig`) and enable the `:lvgl` override in `EXTRA_OVERRIDES` so the lvgl bbappend fetches lvgl `release/v9.3` into `usr/lib/lvgl` at build time.

This gives framebuffer + LVGL support by default when building SO3 for virt64.

## Details
- `IB_CONFIG:so3:virt64 ?= "virt64_fb_defconfig"` (kept weak `?=`, consistent with the file's convention — a layer/capsule can still override).
- `EXTRA_OVERRIDES .= ":lvgl"` enabled; `:soo` left commented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)