### PR TITLE
Make the s3c snapshot lifecycle (save/shutdown/restore) work on virt64

### DIFF
--- a/build/meta-linux/recipes-linux/linux/files/0001-linux-6.12-r0/0002-virt64_guest.dts.patch
+++ b/build/meta-linux/recipes-linux/linux/files/0001-linux-6.12-r0/0002-virt64_guest.dts.patch
@@ -16,7 +16,7 @@
 +		linux,cma {
 +			compatible = "shared-dma-pool";
 +            		reusable;
-+            		size = <0x0 0x6000000>;
++            		size = <0x0 0xa000000>;
 +			alignment = <0x0 0x1000>;
 +            		linux,cma-default;
 +		};

--- a/build/meta-so3/recipes-so3/avz/avz_6.2.0.bb
+++ b/build/meta-so3/recipes-so3/avz/avz_6.2.0.bb
@@ -19,7 +19,7 @@ IB_TARGET = "${IB_AVZ_PATH}"
 # Build AVZ from this local so3 tree's HEAD (so the hypervisor carries the
 # in-tree changes). Bump SRCREV after committing AVZ changes here.
 SRC_URI = "git:///home/rossierd/soo/so3;protocol=file;nobranch=1"
-SRCREV = "54ad443f569be2b740e33c04e3a2d30ab45fe49a"
+SRCREV = "ae8c580018bf7b269c9c53fe817c053bc7205d91"
 
 python do_handle_fetch_git() {
 

--- a/so3/so3/avz/kernel/hypercalls.c
+++ b/so3/so3/avz/kernel/hypercalls.c
@@ -222,5 +222,27 @@ void do_avz_hypercall(void *__args)
 		break;
 	}
 
-	flush_dcache_all();
+	/* Cache maintenance: only the hypercalls which manipulate domain
+	 * memory or stage-2 mappings need a full dcache flush (so that the
+	 * other domains get a coherent view of that memory). Flushing
+	 * unconditionally made every console output and event notification
+	 * pay a full set/way walk; under emulation this is slow enough to
+	 * starve the capsule CPU between two ticks and turn any notification
+	 * burst into a softirq livelock (issue #274). */
+	switch (args->cmd) {
+	case AVZ_INJECT_CAPSULE:
+	case AVZ_S3C_READ_SNAPSHOT:
+	case AVZ_S3C_WRITE_SNAPSHOT:
+	case AVZ_KILL_S3C:
+	case AVZ_GRANT_TABLE_OP:
+#ifdef CONFIG_SOO
+	case AVZ_FBDEV_SET_PFNS:
+	case AVZ_FBDEV_CHANGE_FOCUS:
+#endif
+		flush_dcache_all();
+		break;
+
+	default:
+		break;
+	}
 }

--- a/so3/so3/avz/kernel/injector.c
+++ b/so3/so3/avz/kernel/injector.c
@@ -139,8 +139,10 @@ static void build_domain_context(unsigned int S3C_slotID, struct domain *me, str
 	/* Event channel info */
 	memcpy(domctxt->evtchn, me->evtchn, sizeof(me->evtchn));
 
-	/* Preserve the current system time to facilitate resuming after hibernation */
-	me->avz_shared->current_s_time = NOW();
+	/* current_s_time is written by the capsule itself (in ITS OWN time
+	 * scale) when it handles DC_SUSPEND — do not overwrite it here with
+	 * AVZ's EL2 time, the two time bases are unrelated and the resume
+	 * offset computed from a mixed pair wraps the timer deadlines. */
 
 	/* Get the start_info structure */
 	domctxt->avz_shared = *(me->avz_shared);

--- a/so3/so3/avz/kernel/timer.c
+++ b/so3/so3/avz/kernel/timer.c
@@ -84,5 +84,15 @@ extern void send_guest_virq(struct domain *d, int virq);
 
 void send_timer_event(struct domain *d)
 {
+	/* Do not pile up notifications on a domain which has not consumed the
+	 * previous one yet (e.g. a freshly resumed capsule with interrupts
+	 * still masked in early resume_fn): re-raising the event only
+	 * generates a useless self-SGI per tick on the capsule CPU, and under
+	 * emulation that per-tick overhead can exceed the tick period so the
+	 * guest never gets to run again (livelock). A single pending upcall
+	 * is enough — it is delivered as soon as the domain runs. */
+	if (d->avz_shared->evtchn_upcall_pending)
+		return;
+
 	send_guest_virq(d, VIRQ_TIMER);
 }

--- a/so3/so3/kernel/softirq.c
+++ b/so3/so3/kernel/softirq.c
@@ -55,7 +55,12 @@ void do_softirq(void)
 			break;
 		}
 
-		if (loopmax > 100) /* Probably something wrong ;-) */
+		/* Probably something wrong ;-) — warn ONCE per invocation: printing on
+		 * every iteration makes each loop slower than a timer tick period, so
+		 * the pending softirq is re-raised faster than it is consumed and the
+		 * warning itself turns a transient burst into a permanent livelock
+		 * (seen on the capsule CPU during snapshot resume). */
+		if (loopmax == 101)
 			printk("%s: Warning trying to process softirq on cpu %d for quite a long time (i = %d)...\n", __func__,
 			       cpu, i);
 

--- a/so3/so3/kernel/timer.c
+++ b/so3/so3/kernel/timer.c
@@ -316,7 +316,11 @@ again:
 		t = cur;
 		cur = cur->list_next;
 
-		if (t->expires <= now) {
+		/* Signed comparison, consistent with timer_dev_set_deadline():
+		 * a deadline that wrapped below <now> must be treated as expired,
+		 * otherwise it is never executed here but keeps re-raising
+		 * TIMER_SOFTIRQ in timer_dev_set_deadline (delta <= 0) forever. */
+		if ((int64_t) (t->expires - now) <= 0) {
 			LOG_DEBUG("### %s: NOW: %llu executing timer expires: %llu   ***  delta: %d\n", __func__, now,
 				  t->expires, t->expires - now);
 

--- a/so3/so3/soo/kernel/setup.c
+++ b/so3/so3/soo/kernel/setup.c
@@ -57,11 +57,17 @@ static void resume_fn(void)
 	/* Init the timer too */
 	clocksource_timer_reset();
 
-	/* Now, we need to update the list of all existing timers since our
-	 * host clock will be different. We stored the current system time when saving,
-	 * so we compute the offset according to the current time.
-	 */
+	/* Update the list of all existing timers since the clock reference
+	 * changed across the snapshot/restore.
+	 * Both timestamps are in the capsule's own time scale: current_s_time
+	 * was stored by our DC_SUSPEND handler, and after the snapshot restore
+	 * the restored sys_time plus the clocksource reset above make NOW()
+	 * continue from the suspend point. Clamp for safety — a wrapped
+	 * (negative) offset would corrupt every pending timer deadline. */
 	time_offset = NOW() - avz_shared->current_s_time;
+	if ((int64_t) time_offset < 0)
+		time_offset = 0;
+
 	apply_timer_offset(time_offset);
 
 	raise_softirq(SCHEDULE_SOFTIRQ);

--- a/so3/so3/soo/kernel/soo_guest_activity.c
+++ b/so3/so3/soo/kernel/soo_guest_activity.c
@@ -22,6 +22,7 @@
 
 #include <common.h>
 #include <thread.h>
+#include <timer.h>
 #include <completion.h>
 #include <heap.h>
 #include <list.h>
@@ -216,6 +217,14 @@ void perform_task(dc_event_t dc_event)
 
 		vbs_suspend();
 		DBG("vbstore suspended.\n");
+
+		/* Preserve OUR current system time in the shared page so that
+		 * resume_fn can rebase the pending soft timers. It must be
+		 * expressed in the capsule's own time scale: computing the
+		 * resume offset against a time stamped by AVZ (EL2 uptime)
+		 * mixes two unrelated time bases, wraps the timer deadlines
+		 * and leaves TIMER_SOFTIRQ re-pending forever after resume. */
+		avz_shared->current_s_time = NOW();
 
 		break;
 


### PR DESCRIPTION
## Summary

Validating `s3c-save` / `s3c-shutdown` / `s3c-restore` on virt64 surfaced a
chain of independent bugs. With this branch the full lifecycle works:
repeated `s3c-save → s3c-shutdown → s3c-restore` cycles of the same capsule
complete (exit 0, `S3C_state_living` each time, vuart/vlogs backends
reconnected) with zero softirq warnings across the runs.

## Fixes (one commit each)

- **CMA sizing** — `read/write_snapshot` allocate the whole snapshot
  (slot size + dom_context, ~134 MB since the capsule slot moved to 128 MB)
  with a single `dma_alloc_coherent()`; the agency pool was 96 MB, so
  `s3c-save` died on a `BUG_ON`. Pool grown to 160 MB (virt64 guest DTS).

- **do_softirq warn-once** — the "processing softirq for quite a long time"
  warning printed on every iteration past 100; each print takes longer than
  a tick period (badly so under TCG), so the warning itself turned any
  transient burst into a permanent livelock.

- **VIRQ_TIMER throttle** — every EL2 tick sent a timer event (self-SGI) to
  a capsule that hadn't consumed the previous upcall yet (e.g. early
  resume with interrupts masked). One pending upcall is enough.

- **Targeted dcache flush** — `do_avz_hypercall()` ended *every* hypercall
  with `flush_dcache_all()`; only memory-manipulating hypercalls (inject,
  snapshots, kill, gnttab, fbdev) need it. Console output and event
  notifications are the hot path — under TCG the unconditional full
  set/way walk starved the capsule CPU between ticks.

- **Snapshot-resume time scale** (the root cause of the intermittent
  post-restore livelock, #274) — the resume offset was computed from
  `NOW()` (capsule clock) and `current_s_time` stamped by **AVZ with its
  EL2 clock**: unrelated time bases. With ≥1 pending soft timer in the
  snapshot, the rebased deadlines wrapped: never "expired" for the
  execution loop (unsigned compare) yet always "in the past" for
  `timer_dev_set_deadline` (signed delta) → TIMER_SOFTIRQ re-raised
  forever. The capsule now stamps `current_s_time` itself at DC_SUSPEND,
  AVZ no longer overwrites it, resume_fn clamps a wrapped offset, and the
  timer execution loop uses a signed deadline comparison.

- **SRCREV bump** so the fetched-and-built hypervisor carries the fixes.

## Validation (virt64, QEMU)

- `s3c-save`: 134 MB snapshot taken, zipped to ~11 MB, capsule back to
  `living` (suspend → read → resume).
- `s3c-shutdown`: slot freed, agency fully responsive.
- `s3c-restore`: capsule resumed to `living`; repeated
  save/shutdown/restore cycles of the same capsule green with **zero**
  softirq warnings (previously: systematic livelock, then intermittent
  ~50% per cycle depending on pending timers in the snapshot).
- A second capsule injects cleanly alongside a multiply-restored one.

Closes #274.