### PR TITLE
avz: guard the S3C/capsule cases in the dcache-flush switch with CONFIG_SOO

### DIFF
--- a/so3/so3/avz/kernel/hypercalls.c
+++ b/so3/so3/avz/kernel/hypercalls.c
@@ -230,17 +230,17 @@ void do_avz_hypercall(void *__args)
 	 * starve the capsule CPU between two ticks and turn any notification
 	 * burst into a softirq livelock (issue #274). */
 	switch (args->cmd) {
+#ifdef CONFIG_SOO
 	case AVZ_INJECT_CAPSULE:
 	case AVZ_S3C_READ_SNAPSHOT:
 	case AVZ_S3C_WRITE_SNAPSHOT:
 	case AVZ_KILL_S3C:
 	case AVZ_GRANT_TABLE_OP:
-#ifdef CONFIG_SOO
 	case AVZ_FBDEV_SET_PFNS:
 	case AVZ_FBDEV_CHANGE_FOCUS:
-#endif
 		flush_dcache_all();
 		break;
+#endif
 
 	default:
 		break;


### PR DESCRIPTION
The issue #274 dcache-flush optimization listed `AVZ_INJECT_CAPSULE`,
`AVZ_S3C_{READ,WRITE}_SNAPSHOT`, `AVZ_KILL_S3C` and `AVZ_GRANT_TABLE_OP` in the
flush switch **outside** `#ifdef CONFIG_SOO`, but those command macros are only
defined via `<soo/uapi/soo.h>`, whose include is itself `CONFIG_SOO`-gated.

A **non-SOO AVZ build** (e.g. the `virt64_avz_defconfig` / e1c-capsule config used
by edge-m1) therefore failed to compile:

```
avz/kernel/hypercalls.c:233: error: 'AVZ_INJECT_CAPSULE' undeclared
avz/kernel/hypercalls.c:234: error: 'AVZ_S3C_READ_SNAPSHOT' undeclared
...
make: *** [Makefile:493: avz] Error 2
```

These hypercalls are never issued without `CONFIG_SOO` (their handlers in the
first switch are already guarded), so move the whole case group — flush body
included — inside the existing `#ifdef CONFIG_SOO`. Keeping the body inside the
guard also avoids the `-Wswitch-unreachable` warning that guarding only the
labels would leave.

### Validation
Builds clean both ways with the aarch64 cross toolchain:
- `virt64_avz_defconfig` (CONFIG_SOO **off**) → `hypercalls.o` compiles, no error, no warning.
- `virt64_avz_soo_defconfig` (CONFIG_SOO **on**) → compiles, SOO path unaffected.