### PR TITLE
fix(soo): finish the ME -> S3C rename in user-visible strings (v6.2.1-rc)

### DIFF
--- a/build/meta-linux/recipes-linux/soo/files/0001-linux-6.12-r0/0018-Kconfig.patch
+++ b/build/meta-linux/recipes-linux/soo/files/0001-linux-6.12-r0/0018-Kconfig.patch
@@ -12,7 +12,7 @@
 +        bool "SOO vDummy support for debugging and testing"
 +
 +config VUART_BACKEND
-+	bool "vuart UART Backend support for SOO Mobile Entity consoles"
++	bool "vuart UART Backend support for SO3 capsule consoles"
 +	select SERIAL_CORE_CONSOLE
 +	
 +config VLEDS_BACKEND

--- a/build/meta-linux/recipes-linux/soo/files/0001-linux-6.12-r0/0077-core.c.patch
+++ b/build/meta-linux/recipes-linux/soo/files/0001-linux-6.12-r0/0077-core.c.patch
@@ -219,7 +219,7 @@
 +	int slotID;
 +	S3C_desc_t desc;
 +
-+	lprintk("%s: !! Now terminating all Mobile Entities of this smart object...\n",
++	lprintk("%s: !! Now terminating all SO3 capsules of this smart object...\n",
 +		__func__);
 +
 +	for (slotID = 2; slotID < MAX_DOMAINS; slotID++) {

--- a/build/meta-linux/recipes-linux/soo/files/0001-linux-6.12-rpi4-r0/0018-Kconfig.patch
+++ b/build/meta-linux/recipes-linux/soo/files/0001-linux-6.12-rpi4-r0/0018-Kconfig.patch
@@ -12,7 +12,7 @@
 +        bool "SOO vDummy support for debugging and testing"
 +
 +config VUART_BACKEND
-+	bool "vuart UART Backend support for SOO Mobile Entity consoles"
++	bool "vuart UART Backend support for SO3 capsule consoles"
 +	select SERIAL_CORE_CONSOLE
 +	
 +config VLEDS_BACKEND

--- a/build/meta-linux/recipes-linux/soo/files/0001-linux-6.12-rpi4-r0/0077-core.c.patch
+++ b/build/meta-linux/recipes-linux/soo/files/0001-linux-6.12-rpi4-r0/0077-core.c.patch
@@ -219,7 +219,7 @@
 +	int slotID;
 +	S3C_desc_t desc;
 +
-+	lprintk("%s: !! Now terminating all Mobile Entities of this smart object...\n",
++	lprintk("%s: !! Now terminating all SO3 capsules of this smart object...\n",
 +		__func__);
 +
 +	for (slotID = 2; slotID < MAX_DOMAINS; slotID++) {

--- a/build/meta-usr/recipes-usr/soo/files/0001-usr-linux-1.0-r0/0048-s3c-list.c.patch
+++ b/build/meta-usr/recipes-usr/soo/files/0001-usr-linux-1.0-r0/0048-s3c-list.c.patch
@@ -65,13 +65,13 @@
 +	S3C_id_t id_array[MAX_S3C_DOMAINS];
 +	agency_ioctl_args_t agency_ioctl_args;
 +
-+	printf("*** SOO - Mobile Entity ID Retrieval ***\n\n");
++	printf("*** SOO - SO3 Capsule ID Retrieval ***\n\n");
 +
 +	fd_core = open("/dev/soo/core", O_RDWR);
 +	assert(fd_core > 0);
 +
 +	/* Prepare to terminate the running S3C (dom #2) */
-+	printf("*** List of residing Mobile Entities: \n");
++	printf("*** List of residing SO3 Capsules: \n");
 +
 +	agency_ioctl_args.buffer = &id_array;
 +	ioctl(fd_core, AGENCY_IOCTL_GET_S3C_ID_ARRAY, (unsigned long) &agency_ioctl_args);

--- a/build/meta-usr/recipes-usr/soo/files/0001-usr-linux-1.0-r0/0049-s3c-restore.c.patch
+++ b/build/meta-usr/recipes-usr/soo/files/0001-usr-linux-1.0-r0/0049-s3c-restore.c.patch
@@ -39,7 +39,7 @@
 +	size_t buffer_size;
 +	struct zip_t *zip;
 +
-+        printf("*** SOO - Mobile Entity snapshot restorer ***\n");
++        printf("*** SOO - SO3 Capsule snapshot restorer ***\n");
 +
 +	if (argc != 2) {
 +		printf("## Usage is : s3c-restore <filename> where <filename> is the file containing the S3C snapshot.\n");

--- a/build/meta-usr/recipes-usr/soo/files/0001-usr-linux-1.0-r0/0050-s3c-save.c.patch
+++ b/build/meta-usr/recipes-usr/soo/files/0001-usr-linux-1.0-r0/0050-s3c-save.c.patch
@@ -38,7 +38,7 @@
 +	struct zip_t *zip;
 +        struct agency_ioctl_args args;
 +       
-+        printf("*** SOO - Mobile Entity snapshot saver ***\n");
++        printf("*** SOO - SO3 Capsule snapshot saver ***\n");
 +
 +	if (argc != 2) {
 +		printf("## Usage is : s3c-save <filename> where <filename> is the file containing the S3C snapshot.\n");

--- a/build/meta-usr/recipes-usr/soo/files/0001-usr-linux-1.0-r0/0051-s3c-shutdown.c.patch
+++ b/build/meta-usr/recipes-usr/soo/files/0001-usr-linux-1.0-r0/0051-s3c-shutdown.c.patch
@@ -33,7 +33,7 @@
 +	int fd_core;
 +	agency_ioctl_args_t agency_ioctl_args;
 +
-+	printf("*** SOO - Mobile Entity shutdown ***\n");
++	printf("*** SOO - SO3 Capsule shutdown ***\n");
 +
 +	if (argc != 2) {
 +		printf("## Usage is : s3c-shutdown <S3C ID (1-5)>\n");


### PR DESCRIPTION
## Summary

The ME -> SO3 Capsule rename shipped in v6.2.0 missed a handful of user-facing strings that still print "Mobile Entity":

- `s3c-list`: banner `*** SOO - Mobile Entity ID Retrieval ***` and `*** List of residing Mobile Entities ***`
- `s3c-save` / `s3c-restore`: snapshot saver/restorer banners
- `s3c-shutdown`: shutdown banner
- vuart backend Kconfig prompt (`SOO Mobile Entity consoles`) — virt64 + rpi4 sets
- `core.c` termination message (`Now terminating all Mobile Entities ...`) — virt64 + rpi4 sets

All are replaced with the SO3 Capsule wording. The deliberate historical mentions in `doc/source/{capsules,introduction}.rst` are kept. The edits are in-line substitutions on added patch lines, so hunk counts are unchanged; the new-file app patches were re-verified to apply cleanly.

Candidate fix for a v6.2.1-rc.

## Test plan

- `git grep "Mobile Entit"` returns only the two intentional doc mentions
- the four s3c app new-file patches re-apply cleanly (`patch -p1` in a scratch dir)
- runtime spotted downstream (MICOFE agency): `s3c-list` banner was the visible offender