### PR TITLE
doc: document the release process and fix broken image links

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ SO3.
 
 ## Contributing
 
-The `main` branch always holds the last released version.
+The `main` branch is the development line for the next version.
 
 > [!IMPORTANT]
 > Do not push directly to `main`. Each development is tracked by an issue with
@@ -60,6 +60,17 @@ The `main` branch always holds the last released version.
 
 If you would like to contribute, please first get in touch with the maintainer at
 [daniel.rossier@heig-vd.ch](mailto:daniel.rossier@heig-vd.ch).
+
+## Releases
+
+SO3 uses a branch-per-release model: development happens on `main`, and every
+minor version gets a long-lived `release/vX.Y` maintenance branch on which patch
+releases are tagged (`vX.Y.Z`, or `vX.Y.Z-rc` for candidates). Each tag has a
+matching [GitHub Release](https://github.com/smartobjectoriented/so3/releases).
+
+The full procedure — cutting patch and minor releases, tagging and publishing —
+is documented in
+[Release process](https://smartobjectoriented.github.io/so3/release_process.html).
 
 ## Credits
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -139,7 +139,7 @@ html_theme_options = {'body_max_width': '100%'}
 # Logo shown at the top of the navigation sidebar (every page).
 # The simple "icon + SO3" mark; the full logo with tagline is on the
 # landing page (index.rst).
-html_logo = 'img/SO3_logo.png'
+html_logo = 'img/so3_logo.png'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -6,7 +6,7 @@
    :height: 70px
    :target: http://reds.heig-vd.ch/en/rad
 
-.. image:: img/SO3_with_text.png
+.. image:: img/so3_logo_dark_text.png
    :align: center
    :width: 420px
 
@@ -45,6 +45,7 @@
    lwip
    micropython
    Coding conventions <coding_conventions>
+   release_process
 
 ============================================
 Smart Object Oriented (SO3) Operating System

--- a/doc/source/release_process.rst
+++ b/doc/source/release_process.rst
@@ -1,0 +1,118 @@
+.. _release_process:
+
+Release process
+###############
+
+SO3 follows a branch-per-release model inspired by `LVGL
+<https://github.com/lvgl/lvgl>`_: development happens on ``main``, and every
+minor version gets a long-lived maintenance branch on which patch releases are
+tagged. This keeps stable lines alive for backports while ``main`` moves on.
+
+Overview
+********
+
+Three git objects work together, and GitHub surfaces them in different places:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 20 58
+
+   * - Object
+     - Example
+     - Role
+   * - ``main`` branch
+     - ``main``
+     - Continuous development (the next, unreleased version).
+   * - ``release/vX.Y`` branch
+     - ``release/v6.2``
+     - Long-lived maintenance line for a minor version. Patch fixes land here
+       and are tagged.
+   * - Tag ``vX.Y.Z``
+     - ``v6.2.1``
+     - Immutable point marking a delivered version. Release candidates use the
+       ``-rc`` suffix (``v6.2.1-rc``).
+   * - GitHub Release
+     - "SO3 v6.2.1"
+     - The release page (notes + assets), attached to a tag. Exactly one is
+       flagged *Latest*; ``-rc`` tags are published as *pre-release*.
+
+Versioning
+**********
+
+Versions follow semantic versioning ``vMAJOR.MINOR.PATCH``:
+
+* **MAJOR** — breaking changes to the boot chain, ABI or on-disk formats.
+* **MINOR** — new features, backward compatible. Opens a new ``release/vX.Y``
+  branch.
+* **PATCH** — bug fixes only, cut *on* an existing ``release/vX.Y`` branch.
+
+Release candidates append ``-rc`` (optionally ``-rcN`` for successive
+candidates), e.g. ``v6.3.0-rc``.
+
+Branch layout
+*************
+
+::
+
+   main ──●──●──●──●──●──●───────►   development (next version)
+           \
+   release/v6.2  ●──●──●             maintenance line for 6.2.x
+                 │  │  └─ v6.2.1     (tags live on the branch)
+                 │  └──── v6.2.1-rc
+                 └─────── v6.2.0
+
+While a minor line has not diverged from ``main`` yet (no work started on the
+next minor), its ``release/vX.Y`` branch and ``main`` may point at the same
+commit — that is expected.
+
+Cutting a patch release (``vX.Y.Z``)
+************************************
+
+Patch fixes are committed **on the release branch**, then tagged. If a fix was
+first merged into ``main``, cherry-pick it onto the branch rather than
+fast-forwarding.
+
+.. code-block:: sh
+
+   git checkout release/v6.2
+   git cherry-pick <sha>          # or commit the fix directly
+
+   # optional: publish a candidate first
+   git tag -a v6.2.1-rc -m "so3 v6.2.1-rc"
+   git push origin release/v6.2 v6.2.1-rc
+   gh release create v6.2.1-rc --title "SO3 v6.2.1-rc" \
+       --target release/v6.2 --prerelease --generate-notes
+
+   # final release
+   git tag -a v6.2.1 -m "so3 v6.2.1"
+   git push origin release/v6.2 v6.2.1
+   gh release create v6.2.1 --title "SO3 v6.2.1" \
+       --target release/v6.2 --latest --generate-notes
+
+Cutting a new minor release (``vX.Y.0``)
+****************************************
+
+When ``main`` is ready for a new minor version, branch off it, then tag:
+
+.. code-block:: sh
+
+   git checkout main
+   git checkout -b release/v6.3
+   git push -u origin release/v6.3
+
+   git tag -a v6.3.0 -m "so3 v6.3.0"
+   git push origin v6.3.0
+   gh release create v6.3.0 --title "SO3 v6.3.0" \
+       --target release/v6.3 --latest --generate-notes
+
+Rules of thumb
+**************
+
+* One ``release/vX.Y`` branch **per minor**, not per patch — patches are tags
+  *on* the branch.
+* Tags are immutable: never move or delete a published ``vX.Y.Z`` tag. To
+  correct a release, cut the next patch.
+* Exactly one GitHub Release carries the *Latest* flag; every ``-rc`` Release is
+  a *pre-release* so it never shadows the latest stable version.
+* Once a ``release/vX.Y`` branch has diverged from ``main``, backport fixes with
+  ``git cherry-pick`` — do not fast-forward the branch onto ``main``.

--- a/doc/source/so3_jtag_rpi4.rst
+++ b/doc/source/so3_jtag_rpi4.rst
@@ -375,7 +375,7 @@ Links
 .. |image0| image:: https://www.segger.com/fileadmin/images/products/J-Link/Interface_Description/181129_JTAG.svg
 .. |image1| image:: img/rpi_jtags.jpg
 .. |image2| image:: img/openocd1.png
-.. |image3| image:: img/rick_rick-ThinkPad-P50___-reds-so3-ci-jtag_217.png
+.. |image3| image:: img/so3_ci_jtag.png
 .. |image4| image:: img/gdb.png
 .. |image5| image:: img/gdb2.png
 .. |image6| image:: img/gdb3.png


### PR DESCRIPTION
## What

Documents the SO3 **release workflow** and fixes a few stale image links in the docs.

### Release process doc
Adds `doc/source/release_process.rst` describing the branch-per-release model (inspired by LVGL):

- `main` = development line for the next version
- a long-lived `release/vX.Y` maintenance branch per **minor** version
- semantic version tags `vX.Y.Z` (with `-rc` candidates) cut *on* the release branch
- one matching GitHub Release per tag (single *Latest*, `-rc` published as *pre-release*)

It includes the concrete `git` / `gh` procedures for cutting **patch** and **minor** releases, plus the rules of thumb (one branch per minor, immutable tags, cherry-pick backports once a branch has diverged).

The page is wired into the documentation toctree, and the README gets a **Releases** section pointing at it. The README wording is corrected: `main` is the development line for the next version, not the last released one.

### Image link fixes
Three stale references left over from the earlier image cleanup, pointing at renamed/removed files:

| File | Before → After |
|------|----------------|
| `conf.py` | `SO3_logo.png` → `so3_logo.png` |
| `index.rst` | `SO3_with_text.png` → `so3_logo_dark_text.png` |
| `so3_jtag_rpi4.rst` | `rick_…-ci-jtag_217.png` → `so3_ci_jtag.png` |

## Verification

- Cross-checked every image reference in the docs against `doc/source/img/` — all resolve.
- Sphinx builds clean in strict mode (`sphinx -b html -W`): **0 warnings**.

## Context

Companion to the release infrastructure already set up on the repository: the `release/v5.4`, `release/v6.1`, `release/v6.2` maintenance branches and the per-tag GitHub Releases (with `v6.2.1` as *Latest*).