### PR TITLE
doc: clarify which fixes belong on a release branch

### DIFF
--- a/doc/source/release_process.rst
+++ b/doc/source/release_process.rst
@@ -65,6 +65,26 @@ While a minor line has not diverged from ``main`` yet (no work started on the
 next minor), its ``release/vX.Y`` branch and ``main`` may point at the same
 commit — that is expected.
 
+Which fixes go on a release branch?
+***********************************
+
+Being a bug fix is *not* what sends a change to a release branch. ``main`` is
+the continuous development line and carries both features **and** fixes as they
+land; anything committed there simply ships in the next version. There are two
+kinds of fix:
+
+* **A fix for unreleased code, or one that can wait for the next version.**
+  Nothing special — it is an ordinary commit on ``main`` and ships in the next
+  ``vX.Y.0``. Do *not* touch any release branch.
+* **A fix for an already-published version** (e.g. a bug in ``v6.2.1``) that must
+  ship *before* the next version. Only this case uses the patch-release
+  procedure below: the fix lands on ``release/v6.2`` (tagged ``v6.2.2``) and is
+  also carried to ``main`` so it is not lost at the next minor.
+
+In other words, what sends a change to ``release/vX.Y`` is the need to patch a
+*live, already-released* version — never the mere fact that it is a fix rather
+than a feature.
+
 Cutting a patch release (``vX.Y.Z``)
 ************************************
 


### PR DESCRIPTION
## What

Follow-up to #280. Adds a **"Which fixes go on a release branch?"** section to the release process page, clarifying a point that is easy to get wrong.

Being a bug fix is *not* what routes a change to a release branch. `main` is the continuous development line and carries both features **and** fixes; only one kind of fix uses the patch-release procedure:

| Fix | Where | Ceremony |
|-----|-------|----------|
| Bug in unreleased code, or one that can wait | `main` only | none — ordinary commit, ships in next `vX.Y.0` |
| Bug in an **already-published** version that must ship *before* the next version | `release/vX.Y` (→ e.g. `v6.2.2`) **+** carried to `main` | patch-release procedure |

The section makes explicit that what sends a change to `release/vX.Y` is the need to patch a *live, already-released* version — never the mere fact that it is a fix rather than a feature.

## Verification

- Sphinx builds clean in strict mode (`sphinx -b html -W`): **0 warnings**.