### PR TITLE
doc: list the maintenance branches in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ land there and are tagged as patch releases.
 |------|--------|----------------|--------|
 | 6.2  | [`release/v6.2`](https://github.com/smartobjectoriented/so3/tree/release/v6.2) | [v6.2.1](https://github.com/smartobjectoriented/so3/releases/tag/v6.2.1) | Current stable |
 | 6.1  | [`release/v6.1`](https://github.com/smartobjectoriented/so3/tree/release/v6.1) | [v6.1.0](https://github.com/smartobjectoriented/so3/releases/tag/v6.1.0) | Previous |
-| 5.4  | [`release/v5.4`](https://github.com/smartobjectoriented/so3/tree/release/v5.4) | [v5.4.1](https://github.com/smartobjectoriented/so3/releases/tag/v5.4.1) | Previous |
+| 5.4  | [`release/v5.4`](https://github.com/smartobjectoriented/so3/tree/release/v5.4) | [v5.4.1](https://github.com/smartobjectoriented/so3/releases/tag/v5.4.1) | End of life |
 
 See all versions on the
 [Releases page](https://github.com/smartobjectoriented/so3/releases).

--- a/README.md
+++ b/README.md
@@ -72,6 +72,20 @@ The full procedure — cutting patch and minor releases, tagging and publishing 
 is documented in
 [Release process](https://smartobjectoriented.github.io/so3/release_process.html).
 
+### Maintenance branches
+
+Each minor line has its own long-lived branch. Bug fixes for a published version
+land there and are tagged as patch releases.
+
+| Line | Branch | Latest release | Status |
+|------|--------|----------------|--------|
+| 6.2  | [`release/v6.2`](https://github.com/smartobjectoriented/so3/tree/release/v6.2) | [v6.2.1](https://github.com/smartobjectoriented/so3/releases/tag/v6.2.1) | Current stable |
+| 6.1  | [`release/v6.1`](https://github.com/smartobjectoriented/so3/tree/release/v6.1) | [v6.1.0](https://github.com/smartobjectoriented/so3/releases/tag/v6.1.0) | Previous |
+| 5.4  | [`release/v5.4`](https://github.com/smartobjectoriented/so3/tree/release/v5.4) | [v5.4.1](https://github.com/smartobjectoriented/so3/releases/tag/v5.4.1) | Previous |
+
+See all versions on the
+[Releases page](https://github.com/smartobjectoriented/so3/releases).
+
 ## Credits
 
 We warmly thank our sponsors for their generous support in funding the


### PR DESCRIPTION
## What

Adds a **Maintenance branches** table to the README `Releases` section:

| Line | Branch | Latest release | Status |
|------|--------|----------------|--------|
| 6.2  | `release/v6.2` | v6.2.1 | Current stable |
| 6.1  | `release/v6.1` | v6.1.0 | Previous |
| 5.4  | `release/v5.4` | v5.4.1 | Previous |

## Why

GitHub offers no way to manually order branches — its branch list is sorted by activity, so older maintenance lines (`release/v6.1`, `release/v5.4`) sink into the *Stale* section. This table gives honest, durable visibility of every release line and its status, straight from the landing page, with links to each branch and its latest GitHub Release — independent of the UI sort.

## Notes

Status column is factual (current stable vs previous). Adjust the wording if a formal maintenance/EOL policy is defined later.