### PR TITLE
doc: trim the introduction and release-process pages

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -92,19 +92,6 @@ Where to start
 :ref:`User space <user_space>` · :ref:`Debugging <debugging>`
     The MUSL-based user land, and how to debug SO3 under QEMU/GDB or JTAG.
 
-Development flow
-================
-
-The ``main`` branch contains the last released version.
-
-.. important::
-
-   Do not push directly to ``main``. Each development leads to an issue with its
-   own branch; open a merge/pull request as soon as it is stable enough for
-   review.
-
-If you want to contribute, please first contact `the maintainer <SOO_mail_>`__.
-
 Acknowledgements
 ================
 
@@ -114,5 +101,3 @@ and the `Hasler Foundation <https://haslerstiftung.ch/en/welcome-to-the-hasler-f
 
 We are also grateful to all the contributors — developers, students, researchers
 and community members alike — whose code, ideas and feedback have shaped SO3.
-
-.. _SOO_mail: info@soo.tech

--- a/doc/source/release_process.rst
+++ b/doc/source/release_process.rst
@@ -3,10 +3,9 @@
 Release process
 ###############
 
-SO3 follows a branch-per-release model inspired by `LVGL
-<https://github.com/lvgl/lvgl>`_: development happens on ``main``, and every
-minor version gets a long-lived maintenance branch on which patch releases are
-tagged. This keeps stable lines alive for backports while ``main`` moves on.
+SO3 follows a branch-per-release model: development happens on ``main``, and
+every minor version gets a long-lived maintenance branch on which patch releases
+are tagged. This keeps stable lines alive for backports while ``main`` moves on.
 
 Overview
 ********


### PR DESCRIPTION
Two small documentation cleanups:

- **Release process**: drop the "inspired by LVGL" attribution (and the link to the LVGL repo) from the branch-per-release description. The model stands on its own terms.
- **Landing page**: remove the *Development flow* section (the `main`/branching notes and the "contact the maintainer" line), along with the now-unused `SOO_mail` link target. The page keeps the *Where to start* map and the acknowledgements.

Docs-only, no code changes.