### PR TITLE
Release prep v6.2.2: git-derived boot-banner version + version bump

### DIFF
--- a/build/conf/local.conf
+++ b/build/conf/local.conf
@@ -29,9 +29,9 @@ IB_PLATFORM ?= "virt64"
 #   capsule      SO3 packaged as a capsule.             ITS = virt64_capsule
 
 # --- Versions ---
-PREFERRED_VERSION_so3:virt32  = "6.2.0"
-PREFERRED_VERSION_so3:virt64  = "6.2.0"
-PREFERRED_VERSION_so3:rpi4_64 = "6.2.0"
+PREFERRED_VERSION_so3:virt32  = "6.2.2"
+PREFERRED_VERSION_so3:virt64  = "6.2.2"
+PREFERRED_VERSION_so3:rpi4_64 = "6.2.2"
 
 # --- Configs (kernel defconfig) ---
 # standalone and guest share the plain defconfig; capsule has its own.
@@ -64,9 +64,9 @@ IB_TARGET_ITS:so3:rpi4_64  ?= "rpi4_64_so3"
 # the SO3 section; here we set only the hypervisor version and build config.
 
 # --- Versions ---
-PREFERRED_VERSION_avz:virt64        = "6.2.0"
-PREFERRED_VERSION_avz:rpi4_64       = "6.2.0"
-PREFERRED_VERSION_avz:verdin-imx8mp = "6.2.0"
+PREFERRED_VERSION_avz:virt64        = "6.2.2"
+PREFERRED_VERSION_avz:rpi4_64       = "6.2.2"
+PREFERRED_VERSION_avz:verdin-imx8mp = "6.2.2"
 
 # --- Configs ---
 # virt64_avz_soo_defconfig (CONFIG_SOO=y) is required when AVZ hosts a guest that
@@ -129,7 +129,7 @@ IB_TARGET_ITS:so3:verdin-imx8mp ?= "verdin_imx8mp_avz"
 # standalone variant so U-Boot switches to EL1 first (CONFIG_ARMV8_SWITCH_TO_EL1).
 IB_UBOOT_SWITCH_EL1 ?= "0"
 
-PREFERRED_VERSION_avz:verdin-imx8mp = "6.2.0"
+PREFERRED_VERSION_avz:verdin-imx8mp = "6.2.2"
 IB_CONFIG:avz:verdin-imx8mp ?= "verdin-imx8mp_avz_defconfig"
 
 

--- a/build/meta-so3/recipes-so3/avz/avz_6.2.2.bb
+++ b/build/meta-so3/recipes-so3/avz/avz_6.2.2.bb
@@ -9,7 +9,7 @@ inherit avz
 # Version and revision
  
 PR = "r0"
-PV = "6.2.0"
+PV = "6.2.2"
 
 OVERRIDES += ":avz"
 

--- a/build/meta-so3/recipes-so3/so3/so3_6.2.2.bb
+++ b/build/meta-so3/recipes-so3/so3/so3_6.2.2.bb
@@ -8,7 +8,7 @@ inherit so3
 
 # Version and revision
 PR = "r0"
-PV = "6.2.0"
+PV = "6.2.2"
 
 # :append (not +=) so no space is inserted before ":so3" — otherwise the
 # preceding CPU token parses as "arm "/"aarch64 " and :<cpu> overrides

--- a/so3/so3/Makefile
+++ b/so3/so3/Makefile
@@ -485,8 +485,19 @@ $(sort $(so3-all)): $(so3-dirs) ;
 prepare0: scripts_basic FORCE
 	$(Q)$(MAKE) $(build)=.
 
+# Generated release-version header. The version string is resolved from the
+# git release tag at build time (see scripts/so3version.sh); filechk only
+# rewrites the header when the resolved value actually changes, so it does not
+# force needless rebuilds.
+define filechk_autoversion.h
+	printf '#ifndef SO3_AUTOVERSION_H\n#define SO3_AUTOVERSION_H\n#define SO3_KERNEL_VERSION "%s"\n#endif\n' "$$($(CONFIG_SHELL) $(srctree)/scripts/so3version.sh $(srctree))"
+endef
+
+include/generated/autoversion.h: include/version.h FORCE
+	$(call filechk,autoversion.h)
+
 # All the preparing..
-prepare: prepare0
+prepare: prepare0 include/generated/autoversion.h
 
 PHONY += $(so3-dirs)
 $(so3-dirs): prepare scripts_basic

--- a/so3/so3/include/version.h
+++ b/so3/so3/include/version.h
@@ -35,7 +35,7 @@
  * (see scripts/so3version.sh and include/generated/autoversion.h). Keep this in
  * sync with the current release tag as a safety net.
  */
-#define SO3_KERNEL_VERSION_FALLBACK "6.2.1"
+#define SO3_KERNEL_VERSION_FALLBACK "6.2.2"
 
 /* Release version resolved at build time (git tag -> base version). */
 #include <generated/autoversion.h>

--- a/so3/so3/include/version.h
+++ b/so3/so3/include/version.h
@@ -18,6 +18,7 @@
  */
 
 #ifndef VERSION_H
+#define VERSION_H
 
 /* CHANGES 2023.6.0 */
 /**
@@ -27,6 +28,16 @@
  * - Upgrade U-boot to 2022.04
  */
 
-#define SO3_KERNEL_VERSION "6.2.0"
+/*
+ * Fallback release version, used only when the build tree carries no git
+ * metadata (e.g. a bitbake WORKDIR copy). On a normal git checkout the actual
+ * value of SO3_KERNEL_VERSION is derived from the release tag at build time
+ * (see scripts/so3version.sh and include/generated/autoversion.h). Keep this in
+ * sync with the current release tag as a safety net.
+ */
+#define SO3_KERNEL_VERSION_FALLBACK "6.2.1"
+
+/* Release version resolved at build time (git tag -> base version). */
+#include <generated/autoversion.h>
 
 #endif /* VERSION_H */

--- a/so3/so3/scripts/so3version.sh
+++ b/so3/so3/scripts/so3version.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+#
+# Print the SO3 release version string used in the boot banner.
+#
+# The version is derived from the git release tag (e.g. "v6.2.1") so the
+# banner always matches the current release without any manual bump. Only the
+# base version is kept: any "-<commits>-g<hash>" / "-dirty" suffix added by
+# git-describe on a post-tag (dev) commit is stripped, so both a tagged build
+# and a dev build on top of v6.2.1 report "6.2.1".
+#
+# When the build tree carries no git metadata (e.g. a bitbake WORKDIR copy),
+# fall back to the SO3_KERNEL_VERSION_FALLBACK constant baked into
+# include/version.h.
+#
+# Usage: so3version.sh [srctree]
+#
+
+srctree="${1:-.}"
+
+# Preferred source: the nearest reachable git tag.
+if v=$(cd "$srctree" 2>/dev/null && git describe --tags 2>/dev/null) && [ -n "$v" ]; then
+	# Drop the "-<commits>-g<hash>" and "-dirty" suffixes -> base tag only.
+	v=$(printf '%s' "$v" | sed -e 's/-[0-9][0-9]*-g[0-9a-f]*//' -e 's/-dirty$//')
+	# Drop a leading "v".
+	printf '%s' "${v#v}"
+	exit 0
+fi
+
+# Fallback: the constant checked into version.h.
+sed -n 's/^#define[[:space:]]\{1,\}SO3_KERNEL_VERSION_FALLBACK[[:space:]]\{1,\}"\(.*\)".*/\1/p' \
+	"$srctree/include/version.h"


### PR DESCRIPTION
Prepares the v6.2.2 release (cut on release/v6.2 once merged, v6.2.2-rc first).

Two commits:

* **so3: derive the boot-banner version from the git release tag** — cherry-pick of the autoversion mechanism from feat/so3-release-version (99063bf28). scripts/so3version.sh runs git describe --tags, strips the -N-g<hash>/-dirty suffixes, and a Kbuild filechk rule regenerates include/generated/autoversion.h each build. version.h keeps SO3_KERNEL_VERSION_FALLBACK for trees without .git metadata (the avz bitbake WORKDIR copy).
* **build: bump SO3/AVZ recipes and PREFERRED_VERSION to 6.2.2** — per-release checklist: recipe renames + PV, the 7 PREFERRED_VERSION_{so3,avz} lines in local.conf, and the fallback constant. This also fixes the 6.2.1-cycle incoherence where the recipes had been renamed to 6.2.1 but PV/PREFERRED_VERSION stayed at 6.2.0.

After merge, the release procedure per doc/source/release_process.rst: fast-forward release/v6.2 to main, tag v6.2.2-rc, publish as GitHub pre-release; final v6.2.2 tag after validation.

This supersedes the parked feat/so3-release-version branch (worktree ~/soo/so3-version), which can be deleted afterwards.