### PR TITLE
avz: gate the S3C_CPU paths on CONFIG_SOO

### DIFF
--- a/build/conf/local.conf
+++ b/build/conf/local.conf
@@ -29,9 +29,9 @@ IB_PLATFORM ?= "virt64"
 #   capsule      SO3 packaged as a capsule.             ITS = virt64_capsule
 
 # --- Versions ---
-PREFERRED_VERSION_so3:virt32  = "6.2.2"
-PREFERRED_VERSION_so3:virt64  = "6.2.2"
-PREFERRED_VERSION_so3:rpi4_64 = "6.2.2"
+PREFERRED_VERSION_so3:virt32  = "6.2.3"
+PREFERRED_VERSION_so3:virt64  = "6.2.3"
+PREFERRED_VERSION_so3:rpi4_64 = "6.2.3"
 
 # --- Configs (kernel defconfig) ---
 # standalone and guest share the plain defconfig; capsule has its own.
@@ -64,9 +64,9 @@ IB_TARGET_ITS:so3:rpi4_64  ?= "rpi4_64_so3"
 # the SO3 section; here we set only the hypervisor version and build config.
 
 # --- Versions ---
-PREFERRED_VERSION_avz:virt64        = "6.2.2"
-PREFERRED_VERSION_avz:rpi4_64       = "6.2.2"
-PREFERRED_VERSION_avz:verdin-imx8mp = "6.2.2"
+PREFERRED_VERSION_avz:virt64        = "6.2.3"
+PREFERRED_VERSION_avz:rpi4_64       = "6.2.3"
+PREFERRED_VERSION_avz:verdin-imx8mp = "6.2.3"
 
 # --- Configs ---
 # virt64_avz_soo_defconfig (CONFIG_SOO=y) is required when AVZ hosts a guest that
@@ -129,7 +129,7 @@ IB_TARGET_ITS:so3:verdin-imx8mp ?= "verdin_imx8mp_avz"
 # standalone variant so U-Boot switches to EL1 first (CONFIG_ARMV8_SWITCH_TO_EL1).
 IB_UBOOT_SWITCH_EL1 ?= "0"
 
-PREFERRED_VERSION_avz:verdin-imx8mp = "6.2.2"
+PREFERRED_VERSION_avz:verdin-imx8mp = "6.2.3"
 IB_CONFIG:avz:verdin-imx8mp ?= "verdin-imx8mp_avz_defconfig"
 
 

--- a/build/meta-so3/recipes-so3/avz/avz_6.2.3.bb
+++ b/build/meta-so3/recipes-so3/avz/avz_6.2.3.bb
@@ -9,7 +9,7 @@ inherit avz
 # Version and revision
  
 PR = "r0"
-PV = "6.2.2"
+PV = "6.2.3"
 
 OVERRIDES += ":avz"
 

--- a/build/meta-so3/recipes-so3/so3/so3_6.2.3.bb
+++ b/build/meta-so3/recipes-so3/so3/so3_6.2.3.bb
@@ -8,7 +8,7 @@ inherit so3
 
 # Version and revision
 PR = "r0"
-PV = "6.2.2"
+PV = "6.2.3"
 
 # :append (not +=) so no space is inserted before ":so3" — otherwise the
 # preceding CPU token parses as "arm "/"aarch64 " and :<cpu> overrides

--- a/so3/so3/devices/irq/vgic.c
+++ b/so3/so3/devices/irq/vgic.c
@@ -164,6 +164,7 @@ static enum mmio_result gicv2_handle_irq_target(struct mmio_access *mmio, unsign
 
 enum mmio_result gic_handle_dist_access(struct mmio_access *mmio)
 {
+#ifdef CONFIG_SOO
 	/* Capsules must never reach the physical distributor: their
 	 * interrupts are delivered as events (LR injection through the
 	 * GICV cpu interface), so they don't need it — and a capsule's
@@ -173,9 +174,18 @@ enum mmio_result gic_handle_dist_access(struct mmio_access *mmio)
 	 * return 0 on reads (mmio->value is pre-zeroed by the decoder).
 	 * Capsules run exclusively on S3C_CPU, so the trapping CPU
 	 * identifies the guest; only the agency (CPUs 0..2) keeps the
-	 * pass-through policy below. */
+	 * pass-through policy below.
+	 *
+	 * SOO only: without CONFIG_SOO no CPU is reserved for capsules —
+	 * the guest runs on ALL CPUs, so a trap from S3C_CPU is a regular
+	 * guest access. Discarding it would silently lose any interrupt
+	 * the guest enables or routes from that CPU (a driver whose probe
+	 * lands there then waits forever for its IRQ — seen on
+	 * verdin-imx8mp, where the GICD is trapped for the whole agency). */
+
 	if (smp_processor_id() == S3C_CPU)
 		return MMIO_HANDLED;
+#endif /* CONFIG_SOO */
 
 #ifdef CONFIG_GIC_V3
 	return gicv3_handle_dist_access(mmio);

--- a/so3/so3/devices/timer/arm_timer.c
+++ b/so3/so3/devices/timer/arm_timer.c
@@ -83,8 +83,11 @@ static irq_return_t timer_isr(int irq, void *dev)
 		/* Periodic timer */
 		next_event(arm_timer->reload);
 
-#ifdef CONFIG_AVZ
-		timer_interrupt((smp_processor_id() == S3C_CPU) ? true : false);
+#if defined(CONFIG_AVZ) && defined(CONFIG_SOO)
+		timer_interrupt(smp_processor_id() == S3C_CPU);
+#elif defined(CONFIG_AVZ)
+		/* No capsule CPU without CONFIG_SOO — always the agency path. */
+		timer_interrupt(false);
 #else
 		jiffies++;
 
@@ -131,8 +134,14 @@ void avz_el2_timer_tick(void)
 	/* Same CPU predicate as arm_timer_isr: on the capsule CPU the tick
 	 * must run the periodic path so capsule domains get their
 	 * VIRQ_TIMER event; otherwise a capsule never sees a tick and
-	 * spins forever in calibrate_delay. */
+	 * spins forever in calibrate_delay. Without CONFIG_SOO there is
+	 * no capsule CPU — every CPU runs the agency path. */
+
+#ifdef CONFIG_SOO
 	timer_interrupt(smp_processor_id() == S3C_CPU);
+#else
+	timer_interrupt(false);
+#endif /* CONFIG_SOO */
 }
 #endif /* CONFIG_AVZ */
 

--- a/so3/so3/include/version.h
+++ b/so3/so3/include/version.h
@@ -35,7 +35,7 @@
  * (see scripts/so3version.sh and include/generated/autoversion.h). Keep this in
  * sync with the current release tag as a safety net.
  */
-#define SO3_KERNEL_VERSION_FALLBACK "6.2.2"
+#define SO3_KERNEL_VERSION_FALLBACK "6.2.3"
 
 /* Release version resolved at build time (git tag -> base version). */
 #include <generated/autoversion.h>


### PR DESCRIPTION
## Problem

`S3C_CPU` is defined unconditionally, but treating CPU 3 as "the capsule CPU" is only valid under `CONFIG_SOO`. In a non-SOO AVZ build the guest runs on ALL CPUs, including CPU 3, and two code paths still keyed their behavior on the CPU number alone.

**`gic_handle_dist_access()`** discarded every distributor access trapped from S3C_CPU (introduced by the capsule-injection isolation in #271). On platforms where the GICD is trapped for the whole agency — verdin-imx8mp deliberately unmaps the GICD page from Stage-2 — any interrupt the guest enables or routes from CPU 3 is silently lost.

Symptom on verdin bsp-linux (EDGE-M1 fc): minutes-long boot stalls as unlucky driver probes wait forever for their IRQ, then endless `lcdifv3` `flip_done timed out` / `vblank wait timed out` storms from the DRM worker running on CPU 3, while luckier devices (ethernet, SDIO) work normally. GICv2 platforms (virt64, rpi4_64) never hit this: their agency accesses the GICD directly through Stage-2, so only capsule accesses ever trap.

**`arm_timer_isr()` / `avz_el2_timer_tick()`** ran the periodic/capsule tick path on CPU 3. Harmless today with no capsule domains, but it encodes the same wrong assumption and skips the agency accounting.

## Fix

Gate both on `CONFIG_SOO`: without it every CPU takes the agency path and distributor traps are always forwarded. SOO builds are unchanged.

## Validation

- `verdin-imx8mp_avz_defconfig` (non-SOO) builds clean
- `virt64_avz_soo_defconfig` (SOO) builds clean
- clang-format 19 clean on both files
- Hardware boot test on Verdin iMX8MP in progress (EDGE-M1 side)