### PR TITLE
doc: keep the README release table in sync with the releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ land there and are tagged as patch releases.
 
 | Line | Branch | Latest release | Status |
 |------|--------|----------------|--------|
-| 6.2  | [`release/v6.2`](https://github.com/smartobjectoriented/so3/tree/release/v6.2) | [v6.2.1](https://github.com/smartobjectoriented/so3/releases/tag/v6.2.1) | Current stable |
+| 6.2  | [`release/v6.2`](https://github.com/smartobjectoriented/so3/tree/release/v6.2) | [v6.2.3](https://github.com/smartobjectoriented/so3/releases/tag/v6.2.3) | Current stable |
 | 6.1  | [`release/v6.1`](https://github.com/smartobjectoriented/so3/tree/release/v6.1) | [v6.1.0](https://github.com/smartobjectoriented/so3/releases/tag/v6.1.0) | Previous |
 | 5.4  | [`release/v5.4`](https://github.com/smartobjectoriented/so3/tree/release/v5.4) | [v5.4.1](https://github.com/smartobjectoriented/so3/releases/tag/v5.4.1) | End of life |
 

--- a/doc/source/release_process.rst
+++ b/doc/source/release_process.rst
@@ -124,6 +124,21 @@ When ``main`` is ready for a new minor version, branch off it, then tag:
    gh release create v6.3.0 --title "SO3 v6.3.0" \
        --target release/v6.3 --latest --generate-notes
 
+After tagging: propagate the release to ``main``
+************************************************
+
+A release is not finished when the tag is pushed. Two references to the
+current version live on ``main`` and must be bumped right after every
+release (they drift silently otherwise):
+
+* the *Maintained versions* table in ``README.md`` (the *Latest release*
+  column of the line, and the *Status* column when a new minor line starts);
+* the build-system version pins: rename the ``so3_X.Y.Z.bb`` and
+  ``avz_X.Y.Z.bb`` recipes (under ``build/meta-so3/recipes-so3/``) to the
+  new version and update the ``PREFERRED_VERSION_so3`` /
+  ``PREFERRED_VERSION_avz`` entries in ``build/conf/local.conf`` (see the
+  ``v6.2.3`` bump for a template).
+
 Rules of thumb
 **************
 


### PR DESCRIPTION
The *Maintained versions* table in the README still advertised **v6.2.1** as the latest 6.2 release while v6.2.2 and v6.2.3 have been published — nothing in the release process mentioned the table, so it drifted silently.

- Point the 6.2 line at [v6.2.3](https://github.com/smartobjectoriented/so3/releases/tag/v6.2.3) (the current *Latest*).
- Add an **After tagging** section to the [release process](https://smartobjectoriented.github.io/so3/release_process.html) covering the two `main`-branch references every release must bump: the README table and the build-system version pins (`so3_X.Y.Z.bb`/`avz_X.Y.Z.bb` recipes + `PREFERRED_VERSION` in `local.conf`), as was done manually for the v6.2.2/v6.2.3 releases.