### PR TITLE
doc: CHANGELOG entry for v6.2.3

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,18 @@
 
+v6.2.3 (15 jul 2026)
+
+Patch release on the 6.2 line fixing the non-SOO AVZ configuration on GICv3
+platforms (Verdin iMX8MP), validated on hardware before tagging.
+
+•	Gated the S3C_CPU paths on CONFIG_SOO: in a non-SOO AVZ build the guest
+	runs on all CPUs, but gic_handle_dist_access() still discarded every
+	distributor access trapped from CPU 3 — on verdin-imx8mp (GICD trapped
+	for the whole agency) any interrupt enabled or routed from CPU 3 was
+	silently lost, causing minutes-long boot stalls and lcdifv3
+	flip_done/vblank timeout storms. GICv2 platforms were unaffected.
+•	The periodic/capsule tick path no longer runs on CPU 3 in non-SOO
+	builds (same wrong assumption, agency accounting skipped).
+
 v2021.4.1 (29 jan 2021)
 
 This release includes support for graphics (LVGL) and networking based on “lwip”.

--- a/doc/source/release_process.rst
+++ b/doc/source/release_process.rst
@@ -133,6 +133,8 @@ release (they drift silently otherwise):
 
 * the *Maintained versions* table in ``README.md`` (the *Latest release*
   column of the line, and the *Status* column when a new minor line starts);
+* a ``CHANGELOG`` entry summarizing the release (same content as the GitHub
+  Release notes, kept in the repository for offline reference);
 * the build-system version pins: rename the ``so3_X.Y.Z.bb`` and
   ``avz_X.Y.Z.bb`` recipes (under ``build/meta-so3/recipes-so3/``) to the
   new version and update the ``PREFERRED_VERSION_so3`` /


### PR DESCRIPTION
Adds the missing `CHANGELOG` entry for the [v6.2.3](https://github.com/smartobjectoriented/so3/releases/tag/v6.2.3) patch release (#291: S3C_CPU paths gated on `CONFIG_SOO`, fixing the non-SOO AVZ boot stalls and lcdifv3 timeout storms on verdin-imx8mp), in the file's existing format.

Also adds the `CHANGELOG` to the **After tagging** checklist introduced by #294 — the file had not been touched since v2021.4.1, same silent-drift problem as the README table.

Note: the gap between v2021.4.1 and v6.2.3 remains; backfilling the 5.4/6.1/6.2.0-6.2.2 entries from the GitHub Release notes is possible as a follow-up if wanted.