### PR TITLE
bsp: auto-initialise storage on deploy, clearer error otherwise

### DIFF
--- a/build/meta-bsp/classes/bsp.bbclass
+++ b/build/meta-bsp/classes/bsp.bbclass
@@ -176,7 +176,13 @@ addtask do_deploy_boot_chain before do_deploy
 def __do_deploy_boot(d):
 
     if d.getVar('IB_STORAGE_MODE') not in ("remote", "http"):
-        bb.warn("Now mounting")
+        # Make deploy depend on an initialised storage. In "soft" mode this
+        # creates sdcard.img.<platform> on the fly when it is missing (the
+        # same work as scripts/init_storage.sh), so a fresh tree can deploy
+        # without a separate manual init step. deploy.sh already opened a
+        # sudo session, so the losetup/mkfs done here via `sudo -n` succeeds.
+        __do_fs_check(d)
+        bb.plain("Mounting storage")
         __do_fs_mount(d)
 
     __do_platform_deploy(d)

--- a/build/meta-filesystem/classes/fs_arm_common.bbclass
+++ b/build/meta-filesystem/classes/fs_arm_common.bbclass
@@ -169,7 +169,13 @@ def __do_fs_mount(d):
             os.stat(img_path)
         except OSError as e:
             if e.errno == errno.ENOENT:
-                bb.fatal(f"{img_path} does not exist")
+                bb.fatal(
+                    f"Storage image '{img_path}' does not exist: the filesystem "
+                    f"for platform '{IB_PLATFORM}' has not been initialised yet.\n"
+                    f"Deploy normally creates it automatically; if you reach this, "
+                    f"initialise the storage explicitly by running:\n"
+                    f"    ./scripts/init_storage.sh\n"
+                    f"then run the deploy again.")
 
     p1 = os.path.join(WORKDIR, "p1")
     p2 = os.path.join(WORKDIR, "p2")


### PR DESCRIPTION
## Problem

Deploying on a fresh tree (`./scripts/deploy.sh -a bsp-so3`, `IB_STORAGE_MODE=soft` platforms such as virt64/virt32) failed with a bare, unhelpful message:

```
ERROR: .../filesystem/work/sdcard.img.virt64 does not exist
```

Root cause: `do_deploy` → `__do_deploy_boot()` goes straight to `__do_fs_mount()`; it never runs `__do_fs_check()`, so the SD-card image is never created. It only existed if the user had separately run `scripts/init_storage.sh` first — an undocumented prerequisite.

## Changes

- **`meta-bsp/classes/bsp.bbclass`** — `__do_deploy_boot()` now calls `__do_fs_check(d)` before mounting. In `soft` mode this creates `sdcard.img.<platform>` on the fly when missing (the same work as `scripts/init_storage.sh`). `deploy.sh` has already opened a sudo session, so the `losetup`/`mkfs` via `sudo -n` succeeds. A single `deploy.sh -a bsp-so3` now works end-to-end on a fresh checkout. The misleading `WARNING: Now mounting` is demoted to a plain note.
- **`meta-filesystem/classes/fs_arm_common.bbclass`** — the `ENOENT` path in `__do_fs_mount()` now names the platform and points at `./scripts/init_storage.sh`, as a safety net (and for `hard` mode, where there is no image to auto-create).

## Test

Validated end-to-end on virt64 with **no** pre-existing image:

```
Deploy SO3 image and U-boot
The filesystem image: sdcard.img.virt64 does not exist - creating it
Mounting storage
task do_deploy: Succeeded
NOTE: Tasks Summary: Attempted 12 tasks ... all succeeded.
```

Resulting `sdcard.img.virt64` (2.0G) has the expected FAT32 boot + ext4 rootfs partitions.