### PR TITLE
build: inherit logging in base.bbclass; drop redundant per-recipe inherits

### DIFF
--- a/build/meta-bsp/classes/bsp.bbclass
+++ b/build/meta-bsp/classes/bsp.bbclass
@@ -118,7 +118,6 @@ addtask do_render_its before do_itb
 # This is the uEnv.txt file related to U-boot depending on the BSP
 IB_UENV = "${FILE_DIRNAME}/files/uEnv_${IB_PLATFORM}.txt"
 
-inherit logging
 inherit filesystem
 
 # Platform boot chain — produces the bootloader-side artefacts (flash0.img

--- a/build/meta-bsp/recipes-bsp/capsule/bsp-capsules_1.0.0.bb
+++ b/build/meta-bsp/recipes-bsp/capsule/bsp-capsules_1.0.0.bb
@@ -11,7 +11,6 @@ PR = "r0"
 
 inherit filesystem
 inherit uboot
-inherit logging
 inherit bsp
 
 # Capsules reuse the SO3 ITS templates (e.g. <plat>_capsule.its)

--- a/build/meta-bsp/recipes-bsp/linux/bsp-linux_1.0.bb
+++ b/build/meta-bsp/recipes-bsp/linux/bsp-linux_1.0.bb
@@ -12,7 +12,6 @@ PR = "r0"
 
 inherit filesystem
 inherit linux
-inherit logging
 inherit bsp
 inherit uboot
 inherit atf

--- a/build/meta-bsp/recipes-bsp/so3/bsp-so3_1.0.0.bb
+++ b/build/meta-bsp/recipes-bsp/so3/bsp-so3_1.0.0.bb
@@ -12,7 +12,6 @@ PR = "r0"
 
 inherit filesystem
 inherit uboot
-inherit logging
 inherit bsp
 
 # ITS templates live in the layer (rendered into IB_ITB_PATH by do_itb)

--- a/build/meta-filesystem/classes/filesystem.bbclass
+++ b/build/meta-filesystem/classes/filesystem.bbclass
@@ -24,7 +24,6 @@
 #
 ###################################################################
 
-inherit logging
 inherit utils
 inherit fs_${IB_PLATFORM}
 

--- a/build/meta-filesystem/classes/fs_verdin-imx8mp.bbclass
+++ b/build/meta-filesystem/classes/fs_verdin-imx8mp.bbclass
@@ -7,7 +7,6 @@
 # The caller (deploy.sh / build.sh / mount.sh / umount.sh) is expected
 # to have opened a sudo session beforehand.
 
-inherit logging
 inherit utils
 
 IB_FILESYSTEM_PATH = "${IB_DIR}/filesystem"

--- a/build/meta-filesystem/recipes-filesystem/generic/filesystem_1.0.0.bb
+++ b/build/meta-filesystem/recipes-filesystem/generic/filesystem_1.0.0.bb
@@ -10,7 +10,6 @@ PV = "1.0.0"
 PR = "r0"
 
 inherit filesystem
-inherit logging
 
 do_configure[noexec] = "1"
 do_attach_infrabase[noexec] = "1"

--- a/build/meta-linux/classes/linux.bbclass
+++ b/build/meta-linux/classes/linux.bbclass
@@ -2,7 +2,6 @@
 
 # Class of Linux layer
 
-inherit logging
 
 IB_LINUX_PATH = "${IB_DIR}/linux/linux"
 

--- a/build/meta-rootfs/recipes-rootfs/buildroot/buildroot_2024.11.bb
+++ b/build/meta-rootfs/recipes-rootfs/buildroot/buildroot_2024.11.bb
@@ -10,7 +10,6 @@ PV = "2024.11"
 
 OVERRIDES += ":linux"
 
-inherit logging
 inherit rootfs
 
 SRC_URI = "https://buildroot.org/downloads/buildroot-2024.11.tar.gz;protocol=https"

--- a/build/meta-uboot/recipes-uboot/uboot/uboot_2024.07.bb
+++ b/build/meta-uboot/recipes-uboot/uboot/uboot_2024.07.bb
@@ -12,7 +12,6 @@ inherit filesystem
 inherit uboot
 inherit bsp
 inherit atf
-inherit logging
 
 SRCREV = "3f772959501c99fbe5aa0b22a36efe3478d1ae1c"
 SRC_URI = "git://gitlab.com/u-boot/u-boot.git;nobranch=1;protocol=https"

--- a/build/meta-usr/classes/usr.bbclass
+++ b/build/meta-usr/classes/usr.bbclass
@@ -1,7 +1,6 @@
 # Copyright (c) 2025-2026 EDGEMTech SA
 
 inherit filesystem
-inherit logging
 inherit rootfs
 
 # Class for managing the user space environment

--- a/build/meta/classes/base.bbclass
+++ b/build/meta/classes/base.bbclass
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: MIT
 #
 
+inherit logging
 inherit patch
 inherit utils
 
@@ -205,10 +206,9 @@ do_attach_infrabase () {
 	if [ -d "${IB_TARGET}" ] && [ -f "$ib_manifest" ] && [ "${IB_FORCE_ATTACH}" != "1" ]; then
 		ib_dirty=$(cd "${IB_TARGET}" && LC_ALL=C sha256sum -c --quiet "$ib_manifest" 2>/dev/null | sed -n 's/: FAILED.*$//p')
 		if [ -n "$ib_dirty" ]; then
-			echo "WARNING: Local modifications detected in ${IB_TARGET}, not captured in the ${PN} patch set:" >&2
+			bbwarn "Local modifications detected in ${IB_TARGET}, not captured in the ${PN} patch set:"
 			echo "$ib_dirty" | sed 's|^\./|    |' >&2
-			echo "ERROR: Refusing to re-attach ${PN} (would overwrite the files above). Run 'bitbake ${PN} -c updiff' to fold them into the patch set, or set IB_FORCE_ATTACH=1 to discard them and re-attach (prior tree is kept in ${IB_TARGET}.back)." >&2
-			exit 1
+			bbfatal "Refusing to re-attach ${PN} (would overwrite the files above). Run 'bitbake ${PN} -c updiff' to fold them into the patch set, or set IB_FORCE_ATTACH=1 to discard them and re-attach (prior tree is kept in ${IB_TARGET}.back)."
 		fi
 	fi
 


### PR DESCRIPTION
Follow-up to #298.

## Problem
`do_attach_infrabase` (and other `base.bbclass` shell tasks) use `bbwarn`/`bbfatal`, but `base.bbclass` did not `inherit logging`. In recipes that don't inherit it themselves — the fetched trees (qemu, avz, uboot) — those helpers are undefined, so the attach guard's "local modifications" branch exits **127 (command not found)**, turning a diagnostic warning into a silent hard task failure with no message.

This surfaced while validating a QEMU bbappend: a stale `qemu.attach.sha256` (a known false positive) tripped the branch, and the build died on `bbwarn: command not found` instead of printing the intended guidance.

## Fix
`inherit logging` in `base.bbclass`, matching upstream OpenEmbedded. Since `base` is inherited by every recipe, the `bb*` shell logging helpers are now available everywhere.

- `do_attach_infrabase` uses the idiomatic `bbwarn`/`bbfatal` again (#298 worked around it with plain `echo`; reverted here).
- The 11 now-redundant per-recipe `inherit logging` lines are removed.

## Validation
- `bitbake -p` parses all recipes, 0 errors.
- `bitbake -e bsp-so3` (no longer inherits logging explicitly) still defines `bbfatal()` → confirmed inherited via `base`.