### PR TITLE
rpi4_64: make the I2C/Sense HAT path work on 64-bit

### DIFF
--- a/build/meta-bsp/recipes-bsp/bsp/files/bsp_rpi4_64.inc
+++ b/build/meta-bsp/recipes-bsp/bsp/files/bsp_rpi4_64.inc
@@ -16,6 +16,13 @@ def __do_platform_deploy(d):
     uboot_path = d.getVar('IB_UBOOT_PATH')
 
     run(f"cp -r {filedirname}/../bsp/rpi4/* {dst}/p1")
+
+    # bsp/rpi4/config.txt is shared with the 32-bit BSP and deliberately holds
+    # no arm_64bit/kernel setting; append the 64-bit half of the chain.
+    # FILE_DIRNAME is the *recipe's* directory (recipes-bsp/so3), not this
+    # include's — hence the ../bsp hop, as in the copy above.
+    run(f"cat {filedirname}/../bsp/files/config_rpi4_arm64.txt >> {dst}/p1/config.txt")
+
     run(f"cp {uboot_path}/u-boot.bin {dst}/p1/kernel8.img")
 
     __deploy_arm_common(d)

--- a/build/meta-bsp/recipes-bsp/bsp/files/config_rpi4_arm32.txt
+++ b/build/meta-bsp/recipes-bsp/bsp/files/config_rpi4_arm32.txt
@@ -1,0 +1,7 @@
+
+# --- 32-bit boot chain (appended by bsp_rpi4.inc) ---
+# The deploy installs the arm32 U-Boot as kernel7l.img. arm_64bit=0 is the
+# firmware default, but state both explicitly so the loaded file never depends
+# on the firmware's 32/64-bit filename default.
+arm_64bit=0
+kernel=kernel7l.img

--- a/build/meta-bsp/recipes-bsp/bsp/files/config_rpi4_arm64.txt
+++ b/build/meta-bsp/recipes-bsp/bsp/files/config_rpi4_arm64.txt
@@ -1,0 +1,9 @@
+
+# --- 64-bit boot chain (appended by bsp_rpi4_64.inc) ---
+# The deploy installs the aarch64 U-Boot as kernel8.img. This firmware
+# (bcm2711, Aug 2021) defaults arm_64bit to 0, so without this it starts the
+# cores in 32-bit mode and looks for kernel7l.img, never finds it, and boots
+# nothing at all — no serial output whatsoever. kernel= is stated explicitly so
+# the loaded file never depends on the firmware's filename default.
+arm_64bit=1
+kernel=kernel8.img

--- a/build/meta-bsp/recipes-bsp/bsp/rpi4/config.txt
+++ b/build/meta-bsp/recipes-bsp/bsp/rpi4/config.txt
@@ -65,3 +65,24 @@ max_framebuffers=2
 #dtoverlay=vc4-fkms-v3d
 
 enable_uart=1
+
+# Don't read an attached HAT's EEPROM. The firmware would merge the HAT's own
+# overlay into the device tree it hands to U-Boot, and that DT carries no
+# /chosen/stdout-path — so U-Boot picks its console by DT node order, which the
+# merge perturbs: with a Sense HAT fitted, U-Boot drives the wrong UART and
+# boots in complete silence. SO3 talks to the HAT through its own rpisense
+# driver and never needs the overlay. Applies to both 32- and 64-bit.
+force_eeprom_read=0
+
+# The 32/64-bit boot settings are NOT here: this file is shared by every rpi4
+# BSP, and the two chains need opposite values (kernel7l.img vs kernel8.img).
+# bsp_rpi4.inc / bsp_rpi4_64.inc append the right config_rpi4_arm{32,64}.txt
+# fragment after copying this directory.
+
+# Diagnostic only — echoes the firmware's own boot stage on the UART, which is
+# how you tell a failure *before* U-Boot from a dead board. Leave it OFF for
+# normal boots: to print, the firmware muxes GPIO14/15 to the PL011 and resets
+# its baud, while the DT gives serial0 = the mini-UART (7e215040, the one SO3
+# drives). The pins then stay on the wrong peripheral and U-Boot's output never
+# reaches the wire.
+#uart_2ndstage=1

--- a/so3/so3/devices/i2c/Kconfig
+++ b/so3/so3/devices/i2c/Kconfig
@@ -2,4 +2,4 @@ config I2C_BSC
     default y
     depends on I2C
 	bool "I2C Broadcom Serial Controller (BSC) interface"
-	depends on RPI4
+	depends on RPI4 || RPI4_64

--- a/so3/so3/devices/i2c/i2c_bsc.c
+++ b/so3/so3/devices/i2c/i2c_bsc.c
@@ -211,7 +211,12 @@ static int i2c_bsc_init(dev_t *dev, int fdt_offset)
 	const struct fdt_property *prop;
 	int prop_len;
 	uint32_t mask;
-	uint32_t gpio_regs_addr;
+
+	/* addr_t, not uint32_t: io_map() hands back a virtual address, which on
+	 * arm64 sits at CONFIG_IO_MAPPING_BASE (0xffff9000_00000000) and would
+	 * lose its top half in a 32-bit variable.
+	 */
+	addr_t gpio_regs_addr;
 
 	LOG_DEBUG("I2C broadcom - Initialization\n");
 

--- a/so3/so3/devices/rpisense/Kconfig
+++ b/so3/so3/devices/rpisense/Kconfig
@@ -1,5 +1,5 @@
 config RPI_SENSE
 	bool "Driver for the Sense Hat extension board"
-	depends on RPI4
+	depends on RPI4 || RPI4_64
 	
 	

--- a/so3/so3/devices/rpisense/rpisense.c
+++ b/so3/so3/devices/rpisense/rpisense.c
@@ -35,7 +35,11 @@
 
 #include <device/arch/rpisense.h>
 
-static uint32_t gpio_regs_addr;
+/* addr_t, not uint32_t: io_map() hands back a virtual address, which on arm64
+ * sits at CONFIG_IO_MAPPING_BASE (0xffff9000_00000000) and would lose its top
+ * half in a 32-bit variable.
+ */
+static addr_t gpio_regs_addr;
 
 uint8_t leds_array[SIZE_FB];
 


### PR DESCRIPTION
## Problem

The `i2c_bsc` and `rpisense` drivers come from the 32-bit rpi4 platform and had **never actually run on rpi4_64**. Enabling them there (`CONFIG_I2C_BSC`/`CONFIG_RPI_SENSE` + `status = "ok"` on the `i2c1`/`rpisense` DT nodes) boots to complete silence — no kernel output at all.

Three independent leftovers from the 32→64-bit move, each invisible until a 64-bit build exercised this code:

### 1. Kconfig hangs off a dead symbol

```
devices/i2c/Kconfig:5:       depends on RPI4
devices/rpisense/Kconfig:3:  depends on RPI4
```

`RPI4` no longer exists — `arch/arm32/Kconfig` only carries `VIRT32`; the 64-bit board is `RPI4_64`. So `I2C_BSC` and `RPI_SENSE` are simply **not selectable** on rpi4_64.

`devices/serial/Kconfig:12` already reads `depends on RPI4 || RPI4_64` — it was updated when rpi4_64 landed and i2c/rpisense were missed. This PR uses the same form rather than `RPI4_64` alone, so a returning 32-bit platform keeps working.

### 2. `io_map()` return value truncated to 32 bits

```c
addr_t io_map(addr_t phys, size_t size);   /* 64-bit on arm64 */
uint32_t gpio_regs_addr;                   /* i2c_bsc.c:214, rpisense.c:38 */
gpio_regs_addr = io_map(GPIO_REGS_ADDR, 0xF0);
mask = ioread32(gpio_regs_addr + GPIO_FSEL0_OFF);
```

On arm64 the mapped virtual address sits at `CONFIG_IO_MAPPING_BASE` (`0xffff9000_00000000`), so a `uint32_t` **drops the top half** and the driver dereferences the truncated address. On ARM32 `addr_t` was 32-bit and the code was correct.

Why the total silence: both are `REGISTER_DRIVER_CORE`, so they probe **before** the `POSTCORE` serial console — the abort kills the kernel before there is anything to print with.

### 3. `config.txt` never got the 64-bit boot settings

The deploy installs the aarch64 U-Boot as `kernel8.img`, but this firmware (bcm2711, Aug 2021) defaults `arm_64bit` to 0 and looks for `kernel7l.img` — nothing is loaded, no output. Now sets `arm_64bit=1` and names the kernel explicitly.

### Bonus: the Sense HAT blocked U-Boot entirely

With a HAT fitted the firmware merges the HAT's EEPROM overlay into the DT it hands to U-Boot (`Loaded HAT overlay` in the firmware log). That DT has **no `/chosen/stdout-path`**, so U-Boot picks its console by DT node order — the merge perturbs it and U-Boot drives the wrong UART, booting in silence. Isolated to one variable: same board, same card, HAT removed → U-Boot starts.

`force_eeprom_read=0` avoids it. SO3 talks to the HAT through its own `rpisense` driver and never needs the overlay.

## Test

Real hardware, RPi 4 Model B (0xc03111, 1 GB), Sense HAT fitted:

```
U-Boot 2022.04 (Jul 17 2026 - 10:46:05 +0200)
DRAM:  948 MiB
RPI 4 Model B (0xc03111)
...
Starting kernel ...
********** Smart Object Oriented SO3 Operating System **********
Version 6.2.3
[SO3 USR] Starting the initial process
```

SO3 reaches userspace with `i2c_bsc` and `rpisense` probing at CORE, and the HAT's LED matrix and joystick respond.

## Notes

- `config.txt` is shared by every rpi4 BSP, so the 32/64-bit settings live in the appended `config_rpi4_arm{32,64}.txt` fragments rather than in the file itself. Only `bsp_rpi4_64.inc` consumes one today.
- Enabling `i2c1`/`rpisense` in `rpi4_64.dts` is deliberately **not** part of this PR: they are CORE drivers, so turning them on by default would make every rpi4_64 probe a Sense HAT that may not be there.
- Separate gap noticed while testing, addressed on its own in #305: `build/meta-bsp/recipes-bsp/bsp/rpi4/` ships **no `.dtb`**, so the deploy relies on whatever DTB already sits on the card.
