### PR TITLE
rpi: import uEnv.txt with an explicit format and length

### DIFF
--- a/build/meta-uboot/recipes-uboot/uboot/files/0001-uboot-2022.04-r0/0023-rpi.h.patch
+++ b/build/meta-uboot/recipes-uboot/uboot/files/0001-uboot-2022.04-r0/0023-rpi.h.patch
@@ -22,14 +22,23 @@
  #define ENV_MEM_LAYOUT_SETTINGS \
  	"fdt_high=" FDT_HIGH "\0" \
  	"initrd_high=" INITRD_HIGH "\0" \
-@@ -168,12 +173,21 @@
+@@ -168,12 +173,30 @@
  
  #include <config_distro_bootcmd.h>
  
 +#endif /* 0 */
 +
++/*
++ * Import uEnv.txt with an explicit format and length. Without them, "env
++ * import" scans from the load address for a double-NUL to guess the size, so
++ * it swallows whatever stale memory follows the file: on arm32 that yielded
++ * "input data size = 4447" for a 117-byte file and the import failed with
++ * errno 22. It only appeared to work on arm64 because the byte after the file
++ * happened to be NUL. fatload sets ${filesize}, so use it, and state -t rather
++ * than lean on the "defaulting to text format" warning.
++ */
 +#define CONFIG_BOOTCOMMAND \
-+            "fatload mmc 0 0x02000000 uEnv.txt; env import 0x02000000; run start\0\0" \
++            "fatload mmc 0 0x02000000 uEnv.txt; env import -t 0x02000000 ${filesize}; run start\0\0" \
 +            "bootdelay=0\0"
 +
 +


### PR DESCRIPTION
## Problem

The RPi `CONFIG_BOOTCOMMAND` (`include/configs/rpi.h`, via `0023-rpi.h.patch`) reads:

```
fatload mmc 0 0x02000000 uEnv.txt; env import 0x02000000; run start
```

`env import` is given **no size and no format**, so U-Boot scans from the load address for a double-NUL to guess how much to import — swallowing whatever stale memory follows the file. On arm32:

```
117 bytes read in 30 ms (2.9 KiB/s)
## Warning: defaulting to text format
## Info: input data size = 4447 = 0x115F      <-- for a 117-byte file
## Error: Environment import failed: errno = 22
```

The boot still succeeds *by accident*: `start` sits early enough in `uEnv.txt` to be imported before the trailing garbage aborts the rest.

**This is not 32-bit specific** — the size has always been guessed. It merely looked correct on arm64, where the byte right after the file happened to be NUL:

```
## Info: input data size = 118 = 0x76         <-- same 117-byte file, arm64
```

## Fix

`fatload` sets `${filesize}` immediately before, so pass it, and state `-t` instead of relying on the "defaulting to text format" warning:

```
fatload mmc 0 0x02000000 uEnv.txt; env import -t 0x02000000 ${filesize}; run start
```

## Test

Real hardware (RPi 4 Model B, 1 GB, Sense HAT), **both** chains:

- **arm32** — the `Error: Environment import failed` and the format warning are gone; SO3 boots.
- **arm64** — no regression; SO3 boots.

## Note

`include/configs/rpi.h` is shared by every RPi board and both word sizes, so this fixes the guess everywhere at once.