### PR TITLE
so3: state the architecture in the boot banner

### DIFF
--- a/so3/so3/include/banner.h
+++ b/so3/so3/include/banner.h
@@ -3,9 +3,16 @@
 
 #include <version.h>
 
+/*
+ * CONFIG_ARCH ("arm32", "arm64", ...) is spelled out in the banner because the
+ * same platform can be built either way — on a Raspberry Pi 4 in particular,
+ * where a 32- and a 64-bit chain differ only by which kernel*.img the firmware
+ * picks up, there is otherwise no way to tell from the console which one
+ * actually booted.
+ */
 #define SO3_BANNER \
 	"\n\n********** Smart Object Oriented SO3 Operating System **********\n\
 Copyright (c) 2014-2026 REDS Institute, HEIG-VD, Yverdon\n\
-Version " SO3_KERNEL_VERSION "\n\n"
+Version " SO3_KERNEL_VERSION " (" CONFIG_ARCH ")\n\n"
 
-#endif /* BENNER_H */
+#endif /* BANNER_H */


### PR DESCRIPTION
## Why

```
********** Smart Object Oriented SO3 Operating System **********
Copyright (c) 2014-2026 REDS Institute, HEIG-VD, Yverdon
Version 6.2.3
```

The same platform can be built either way, and on a Raspberry Pi 4 the 32- and the 64-bit chains differ **only** by which `kernel*.img` the firmware picks up. Nothing on the console told you which one had actually booted — which is exactly the kind of thing you want to read off the log rather than infer.

## What

```
Version 6.2.3 (arm64)
```

Uses `CONFIG_ARCH` — the string Kconfig already defines (`#define CONFIG_ARCH "arm64"`) — so it needs no maintenance when an architecture is added, and it is a compile-time constant, so the banner stays a plain macro.

## Test

Booted on real hardware (RPi 4 Model B), both chains:

- 32-bit → `Version 6.2.3 (arm32)`
- 64-bit → `Version 6.2.3 (arm64)`