### PR TITLE
doc: note the e-mail alignment in the v6.2.4 CHANGELOG entry

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -64,6 +64,9 @@ both word sizes.
 	failing on a bare "sdcard.img.<plat> does not exist" — init_storage.sh was
 	an undocumented prerequisite.
 
+•	Aligned the copyright e-mail on daniel.rossier@heig-vd.ch across the tree —
+	the address README.md points contributors to.
+
 v6.2.3 (15 jul 2026)
 
 Patch release on the 6.2 line fixing the non-SOO AVZ configuration on GICv3


### PR DESCRIPTION
The v6.2.4 entry was written before #309 landed, so it does not mention it. Adding the line now, while the tag can still reflect the tree it describes.