### PR TITLE
ci: run Build and Style on the release branches too

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,8 +4,9 @@ on:
   push:
     branches:
       - main
+      - "release/**"
   pull_request:
-    branches: ["main"]
+    branches: ["main", "release/**"]
 
 # Smoke-build SO3 with Infrabase (bitbake) inside the so3-env image. Both the
 # kernel (build.sh -x so3) and the user space (build.sh -x usr-so3, which also

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -8,9 +8,9 @@ concurrency:
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "release/**"]
   pull_request:
-    branches: ["main"]
+    branches: ["main", "release/**"]
 
 jobs:
   formatting-check:

--- a/doc/source/release_process.rst
+++ b/doc/source/release_process.rst
@@ -141,6 +141,20 @@ release (they drift silently otherwise):
   ``PREFERRED_VERSION_avz`` entries in ``build/conf/local.conf`` (see the
   ``v6.2.3`` bump for a template).
 
+Before tagging: check the CI
+***************************
+
+The ``Build`` workflow runs on ``main`` **and on every** ``release/**``
+**branch**, so the commit a tag will point at has always been built. Check it
+before tagging::
+
+   gh run list --workflow Build --branch release/v6.2
+
+Tagging a red commit is how ``v6.2.4`` shipped a tree that no fresh clone
+could build. ``build (virt32)`` and ``build (virt64)`` are required status
+checks on ``main`` for the same reason: merging on red stays possible for a
+maintainer, but never by accident.
+
 Rules of thumb
 **************
 


### PR DESCRIPTION
Both workflows only triggered on `main`, yet **tags are cut on `release/vX.Y`** — so the very commits a release points at were the only ones never built. That is the structural half of how `v6.2.4` shipped a tree no fresh clone could build (the other half, the materialized lvgl files, is fixed by #313).

- `build.yml` / `style.yml`: add `release/**` to the `push` and `pull_request` triggers (`Docs` already runs on every ref).
- `release_process.rst`: a short "Before tagging: check the CI" section, pointing at `gh run list --workflow Build --branch release/v6.2`, and noting that `build (virt32)`/`build (virt64)` are now required status checks on `main`.

Prerequisite for cutting `v6.2.5` on `release/v6.2` with CI validation.