### PR TITLE
doc: v6.2.5 release bump

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,29 @@
 
+v6.2.5 (10 aug 2026)
+
+Patch release on the 6.2 line, fixing the release plumbing itself: the v6.2.4
+tree could not be built from a fresh clone at all.
+
+	•	The tree-wide copyright e-mail alignment ran over a built working tree
+		and committed 37 files the build materializes itself: usr/lib/lv_conf.h,
+		the usr/lib/slv/ sources, the quilt staging directory usr/patches/ and
+		the generated usr/src/{fillfb,lvgl_*}.c. On a fresh clone the lvgl patch
+		set then found its own outputs already in place and do_patch died on the
+		very first patch ("would create lib/lv_conf.h, which already exists").
+		Local incremental trees never saw it — only fresh clones and the CI,
+		which had been red since. The files are untracked and the whole family
+		is now in .gitignore.
+
+	•	The Build and Style workflows only ran on main, yet tags are cut on
+		release/vX.Y — the very commits a release points at were the only ones
+		never built. They now also run on release/**, and release_process.rst
+		documents the pre-tag check. On main, build (virt32) and build (virt64)
+		are required status checks.
+
+	•	SO3_KERNEL_VERSION_FALLBACK is back in sync with the tag. A build from a
+		tree without git metadata (tarball, bitbake workdir copy) banners this
+		constant, and v6.2.4 shipped it still reading 6.2.3.
+
 v6.2.4 (17 jul 2026)
 
 Patch release on the 6.2 line. Mostly the Raspberry Pi 4 support, whose 64-bit

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ land there and are tagged as patch releases.
 
 | Line | Branch | Latest release | Status |
 |------|--------|----------------|--------|
-| 6.2  | [`release/v6.2`](https://github.com/smartobjectoriented/so3/tree/release/v6.2) | [v6.2.4](https://github.com/smartobjectoriented/so3/releases/tag/v6.2.4) | Current stable |
+| 6.2  | [`release/v6.2`](https://github.com/smartobjectoriented/so3/tree/release/v6.2) | [v6.2.5](https://github.com/smartobjectoriented/so3/releases/tag/v6.2.5) | Current stable |
 | 6.1  | [`release/v6.1`](https://github.com/smartobjectoriented/so3/tree/release/v6.1) | [v6.1.0](https://github.com/smartobjectoriented/so3/releases/tag/v6.1.0) | Previous |
 | 5.4  | [`release/v5.4`](https://github.com/smartobjectoriented/so3/tree/release/v5.4) | [v5.4.1](https://github.com/smartobjectoriented/so3/releases/tag/v5.4.1) | End of life |
 

--- a/build/conf/local.conf
+++ b/build/conf/local.conf
@@ -36,9 +36,9 @@ IB_BUILD_QEMU ?= "1"
 #   capsule      SO3 packaged as a capsule.             ITS = virt64_capsule
 
 # --- Versions ---
-PREFERRED_VERSION_so3:virt32  = "6.2.4"
-PREFERRED_VERSION_so3:virt64  = "6.2.4"
-PREFERRED_VERSION_so3:rpi4_64 = "6.2.4"
+PREFERRED_VERSION_so3:virt32  = "6.2.5"
+PREFERRED_VERSION_so3:virt64  = "6.2.5"
+PREFERRED_VERSION_so3:rpi4_64 = "6.2.5"
 
 # --- Configs (kernel defconfig) ---
 # standalone and guest share the plain defconfig; capsule has its own.
@@ -71,9 +71,9 @@ IB_TARGET_ITS:so3:rpi4_64  ?= "rpi4_64_so3"
 # the SO3 section; here we set only the hypervisor version and build config.
 
 # --- Versions ---
-PREFERRED_VERSION_avz:virt64        = "6.2.4"
-PREFERRED_VERSION_avz:rpi4_64       = "6.2.4"
-PREFERRED_VERSION_avz:verdin-imx8mp = "6.2.4"
+PREFERRED_VERSION_avz:virt64        = "6.2.5"
+PREFERRED_VERSION_avz:rpi4_64       = "6.2.5"
+PREFERRED_VERSION_avz:verdin-imx8mp = "6.2.5"
 
 # --- Configs ---
 # virt64_avz_soo_defconfig (CONFIG_SOO=y) is required when AVZ hosts a guest that
@@ -136,7 +136,7 @@ IB_TARGET_ITS:so3:verdin-imx8mp ?= "verdin_imx8mp_avz"
 # standalone variant so U-Boot switches to EL1 first (CONFIG_ARMV8_SWITCH_TO_EL1).
 IB_UBOOT_SWITCH_EL1 ?= "0"
 
-PREFERRED_VERSION_avz:verdin-imx8mp = "6.2.4"
+PREFERRED_VERSION_avz:verdin-imx8mp = "6.2.5"
 IB_CONFIG:avz:verdin-imx8mp ?= "verdin-imx8mp_avz_defconfig"
 
 

--- a/build/meta-so3/recipes-so3/avz/avz_6.2.5.bb
+++ b/build/meta-so3/recipes-so3/avz/avz_6.2.5.bb
@@ -9,7 +9,7 @@ inherit avz
 # Version and revision
  
 PR = "r0"
-PV = "6.2.4"
+PV = "6.2.5"
 
 OVERRIDES += ":avz"
 

--- a/build/meta-so3/recipes-so3/so3/so3_6.2.5.bb
+++ b/build/meta-so3/recipes-so3/so3/so3_6.2.5.bb
@@ -8,7 +8,7 @@ inherit so3
 
 # Version and revision
 PR = "r0"
-PV = "6.2.4"
+PV = "6.2.5"
 
 # :append (not +=) so no space is inserted before ":so3" — otherwise the
 # preceding CPU token parses as "arm "/"aarch64 " and :<cpu> overrides

--- a/build/meta-toolchain/recipes-toolchain/musl/files/config.mak
+++ b/build/meta-toolchain/recipes-toolchain/musl/files/config.mak
@@ -19,6 +19,17 @@
 GNU_SITE = https://ftp.gnu.org/gnu
 DL_CMD = wget -c --tries=5 --waitretry=10 --timeout=30 -O
 
+# Same story for the musl tarball itself: musl.libc.org is a single host with
+# no mirror rotation, and when it goes down (timeouts, then "Unable to
+# establish SSL connection" — observed 2026-08-10, both CI platforms and from
+# outside CI) the toolchain build fails at ~2 min and no amount of retrying
+# helps. Fetch it from the MacPorts distfiles mirror, which carries the exact
+# upstream tarball. musl-cross-make checks every download against
+# hashes/<file>.sha1, so a mirror serving anything else fails the build loudly
+# rather than silently building something different (verified: the mirrored
+# musl-1.2.5.tar.gz matches hashes/musl-1.2.5.tar.gz.sha1).
+MUSL_SITE = https://distfiles.macports.org/musl
+
 BINUTILS_VER = 2.44
 GCC_VER = 12.4.0
 # MUSL_VER = git-master


### PR DESCRIPTION
Propagates the `v6.2.5` release to `main`, as `release_process.rst` requires right after a tag:

- the *Maintained versions* table in `README.md`
- a `CHANGELOG` entry mirroring the release notes
- the build-system pins: `so3_`/`avz_` recipes renamed to 6.2.5 with their `PV`, and the `PREFERRED_VERSION_so3` / `PREFERRED_VERSION_avz` entries in `local.conf`

It also carries the musl mirror fix (cherry-picked from the release branch) so `main` builds again: `musl.libc.org` currently serves its web page but stalls on the tarball (a 256 KB range times out at 60 s; the MacPorts mirror delivers it in 0.13 s), which is what turned every CI build red today. musl-cross-make verifies each download against `hashes/<file>.sha1`, and the mirrored tarball matches.