### PR TITLE
so3: set the fallback release version to 6.3.0

### DIFF
--- a/doc/source/release_process.rst
+++ b/doc/source/release_process.rst
@@ -162,6 +162,13 @@ could build. ``build (virt32)`` and ``build (virt64)`` are required status
 checks on ``main`` for the same reason: merging on red stays possible for a
 maintainer, but never by accident.
 
+Check ``SO3_KERNEL_VERSION_FALLBACK`` too: it must already read the version
+being tagged, since the tagged tree is what a gitless build banners. It
+appears twice in this page on purpose — bump it **in the release commit set**
+so the tag is right, and again when propagating to ``main`` so the next
+release does not start a version behind (``main`` sat at ``6.2.4`` while
+``release/v6.2`` was at ``6.2.5``).
+
 Rules of thumb
 **************
 

--- a/so3/so3/include/version.h
+++ b/so3/so3/include/version.h
@@ -35,7 +35,7 @@
  * (see scripts/so3version.sh and include/generated/autoversion.h). Keep this in
  * sync with the current release tag as a safety net.
  */
-#define SO3_KERNEL_VERSION_FALLBACK "6.2.4"
+#define SO3_KERNEL_VERSION_FALLBACK "6.3.0"
 
 /* Release version resolved at build time (git tag -> base version). */
 #include <generated/autoversion.h>


### PR DESCRIPTION
Prepares the `v6.3.0` cut: `SO3_KERNEL_VERSION_FALLBACK` is what a build from a tree without git metadata (tarball, bitbake workdir copy) banners, so it has to be right *before* the tag — `v6.2.4` shipped it a release behind, which `v6.2.5` then had to fix.

Note: `main` was still reading **6.2.4**. The 6.2.5 resync lives on `release/v6.2` only, because the after-tag propagation to `main` carries the CHANGELOG, the README table and the recipe pins — not this constant. Worth adding to the checklist.

`release/v6.3` is branched from `main` once this lands.