### PR TITLE
doc: v6.3.0 release bump

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,36 @@
 
+v6.3.0 (12 aug 2026)
+
+Minor release opening the 6.3 line. It carries the developer build container
+and a documentation correctness pass on top of v6.2.5.
+
+	•	A ready-made build environment: docker/build-env plus scripts/dbuild.sh.
+		The image carries only the environment — both Arm 64-bit toolchains,
+		including the bare-metal aarch64-none-elf the SO3 and AVZ kernels need
+		and that hand-provisioned hosts routinely miss, the 32-bit apt
+		toolchains, and the host packages listed in packages.txt. The repository
+		stays on the host, bind-mounted at its own absolute path so bitbake
+		stamps and the buildroot host tree stay valid and a tree can be built
+		from inside or outside the container interchangeably, and the container
+		runs as the calling host user so nothing comes back root-owned.
+		One entry point covers everything: dbuild.sh --build to make the image,
+		a bare dbuild.sh for an interactive shell with env.sh already sourced,
+		and dbuild.sh <script> for any front-end script (st.sh -d included, the
+		X11 display and cookie are forwarded). The CI images
+		(Dockerfile.toolchains, Dockerfile.env) and the LVGL perf-rig images
+		are untouched.
+
+	•	A correctness pass over the documentation set: the hypercall, driver,
+		ITS and application inventories match the tree again, kernel paths are
+		quoted relative to so3/so3, the coding conventions state what the CI
+		actually enforces, the JTAG chapter is up to date and the documentation
+		version is derived from the release tag.
+
+	•	Everything in v6.2.5: the untracked build-materialized user-space files
+		that made a fresh clone unbuildable, Build and Style running on the
+		release branches so a release commit is validated before it is tagged,
+		and the musl tarball fetched from a mirror.
+
 v6.2.5 (10 aug 2026)
 
 Patch release on the 6.2 line, fixing the release plumbing itself: the v6.2.4

--- a/README.md
+++ b/README.md
@@ -79,8 +79,9 @@ land there and are tagged as patch releases.
 
 | Line | Branch | Latest release | Status |
 |------|--------|----------------|--------|
-| 6.2  | [`release/v6.2`](https://github.com/smartobjectoriented/so3/tree/release/v6.2) | [v6.2.5](https://github.com/smartobjectoriented/so3/releases/tag/v6.2.5) | Current stable |
-| 6.1  | [`release/v6.1`](https://github.com/smartobjectoriented/so3/tree/release/v6.1) | [v6.1.0](https://github.com/smartobjectoriented/so3/releases/tag/v6.1.0) | Previous |
+| 6.3  | [`release/v6.3`](https://github.com/smartobjectoriented/so3/tree/release/v6.3) | [v6.3.0](https://github.com/smartobjectoriented/so3/releases/tag/v6.3.0) | Current stable |
+| 6.2  | [`release/v6.2`](https://github.com/smartobjectoriented/so3/tree/release/v6.2) | [v6.2.5](https://github.com/smartobjectoriented/so3/releases/tag/v6.2.5) | Previous |
+| 6.1  | [`release/v6.1`](https://github.com/smartobjectoriented/so3/tree/release/v6.1) | [v6.1.0](https://github.com/smartobjectoriented/so3/releases/tag/v6.1.0) | End of life |
 | 5.4  | [`release/v5.4`](https://github.com/smartobjectoriented/so3/tree/release/v5.4) | [v5.4.1](https://github.com/smartobjectoriented/so3/releases/tag/v5.4.1) | End of life |
 
 See all versions on the

--- a/build/conf/local.conf
+++ b/build/conf/local.conf
@@ -36,9 +36,9 @@ IB_BUILD_QEMU ?= "1"
 #   capsule      SO3 packaged as a capsule.             ITS = virt64_capsule
 
 # --- Versions ---
-PREFERRED_VERSION_so3:virt32  = "6.2.5"
-PREFERRED_VERSION_so3:virt64  = "6.2.5"
-PREFERRED_VERSION_so3:rpi4_64 = "6.2.5"
+PREFERRED_VERSION_so3:virt32  = "6.3.0"
+PREFERRED_VERSION_so3:virt64  = "6.3.0"
+PREFERRED_VERSION_so3:rpi4_64 = "6.3.0"
 
 # --- Configs (kernel defconfig) ---
 # standalone and guest share the plain defconfig; capsule has its own.
@@ -71,9 +71,9 @@ IB_TARGET_ITS:so3:rpi4_64  ?= "rpi4_64_so3"
 # the SO3 section; here we set only the hypervisor version and build config.
 
 # --- Versions ---
-PREFERRED_VERSION_avz:virt64        = "6.2.5"
-PREFERRED_VERSION_avz:rpi4_64       = "6.2.5"
-PREFERRED_VERSION_avz:verdin-imx8mp = "6.2.5"
+PREFERRED_VERSION_avz:virt64        = "6.3.0"
+PREFERRED_VERSION_avz:rpi4_64       = "6.3.0"
+PREFERRED_VERSION_avz:verdin-imx8mp = "6.3.0"
 
 # --- Configs ---
 # virt64_avz_soo_defconfig (CONFIG_SOO=y) is required when AVZ hosts a guest that
@@ -136,7 +136,7 @@ IB_TARGET_ITS:so3:verdin-imx8mp ?= "verdin_imx8mp_avz"
 # standalone variant so U-Boot switches to EL1 first (CONFIG_ARMV8_SWITCH_TO_EL1).
 IB_UBOOT_SWITCH_EL1 ?= "0"
 
-PREFERRED_VERSION_avz:verdin-imx8mp = "6.2.5"
+PREFERRED_VERSION_avz:verdin-imx8mp = "6.3.0"
 IB_CONFIG:avz:verdin-imx8mp ?= "verdin-imx8mp_avz_defconfig"
 
 

--- a/build/meta-so3/recipes-so3/avz/avz_6.3.0.bb
+++ b/build/meta-so3/recipes-so3/avz/avz_6.3.0.bb
@@ -9,7 +9,7 @@ inherit avz
 # Version and revision
  
 PR = "r0"
-PV = "6.2.5"
+PV = "6.3.0"
 
 OVERRIDES += ":avz"
 

--- a/build/meta-so3/recipes-so3/so3/so3_6.3.0.bb
+++ b/build/meta-so3/recipes-so3/so3/so3_6.3.0.bb
@@ -8,7 +8,7 @@ inherit so3
 
 # Version and revision
 PR = "r0"
-PV = "6.2.5"
+PV = "6.3.0"
 
 # :append (not +=) so no space is inserted before ":so3" — otherwise the
 # preceding CPU token parses as "arm "/"aarch64 " and :<cpu> overrides


### PR DESCRIPTION
Propagates the `v6.3.0` release to `main`, as `release_process.rst` requires right after a tag:

- the *Maintained versions* table in `README.md` — 6.3 becomes the current stable line, 6.2 the previous one, 6.1 end of life
- a `CHANGELOG` entry mirroring the release notes
- the build-system pins: `so3_`/`avz_` recipes renamed to 6.3.0 with their `PV`, and the `PREFERRED_VERSION_so3` / `PREFERRED_VERSION_avz` entries in `local.conf`

`SO3_KERNEL_VERSION_FALLBACK` is already at 6.3.0 — it was bumped before the tag (#317), which is the half that had been missed for v6.2.5.