### PR TITLE
usr: fix the ping build and its ICMP reply parsing

### DIFF
--- a/doc/source/build_system.rst
+++ b/doc/source/build_system.rst
@@ -33,7 +33,7 @@ layers. The canonical, continuously-tested list is the base container recipe
 ``docker/Dockerfile.toolchains`` — mirror it when setting up a bare host.
 For development, the same environment is available as a ready-made build
 container: ``scripts/dbuild.sh --build`` then ``scripts/dbuild.sh build.sh
-bsp-linux`` (or bare ``dbuild.sh`` for a shell) runs any front-end script
+bsp-so3`` (or bare ``dbuild.sh`` for a shell) runs any front-end script
 inside it, with the repository bind-mounted at its own path and the container
 running as the calling user — see ``docker/README.md``.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -17,13 +17,13 @@ user so everything it writes stays yours.
 
 ```
 ./scripts/dbuild.sh --build            # build the so3-build:1.0 image (once)
-./scripts/dbuild.sh build.sh bsp-linux # run any front-end script inside
+./scripts/dbuild.sh build.sh bsp-so3   # run any front-end script inside
 ./scripts/dbuild.sh                    # interactive shell, env.sh sourced
 ./scripts/dbuild.sh st.sh -d           # graphical QEMU from the container
 ```
 
 Caller environment variables are not forwarded; pass them through the
-command: `./scripts/dbuild.sh env IB_FORCE_ATTACH=1 build.sh bsp-linux`.
+command: `./scripts/dbuild.sh env IB_FORCE_ATTACH=1 build.sh bsp-so3`.
 
 The images below remain the CI/perf-rig side of the house.
 

--- a/docker/build-env/Dockerfile
+++ b/docker/build-env/Dockerfile
@@ -8,7 +8,7 @@
 # CMake caches and the *.attach.sha256 manifests all embed absolute paths).
 #
 # Build the image:  scripts/dbuild.sh --build
-# Use it:           scripts/dbuild.sh build.sh bsp-linux
+# Use it:           scripts/dbuild.sh build.sh bsp-so3
 #                   scripts/dbuild.sh st.sh -d
 #
 # The build context is this directory only — never the project root,

--- a/docker/build-env/bashrc
+++ b/docker/build-env/bashrc
@@ -54,8 +54,8 @@ you are running as the host user, so anything you produce stays yours.
 env.sh is already sourced.
 
   build.sh -l                 list recipes
-  build.sh bsp-linux          build the Linux BSP (bsp-so3 for SO3)
-  deploy.sh bsp-linux         deploy (FIT + rootfs + sdcard)
+  build.sh bsp-so3            build the SO3 BSP (bsp-linux for Linux)
+  deploy.sh bsp-so3           deploy (FIT + rootfs + sdcard)
   st.sh / st.sh -d            run in QEMU (headless / graphical)
   exit                        leave the container
 

--- a/scripts/dbuild.sh
+++ b/scripts/dbuild.sh
@@ -10,8 +10,8 @@
 # Usage:
 #   dbuild.sh --build              Build (or rebuild) the image
 #   dbuild.sh                      Interactive shell inside the container
-#   dbuild.sh build.sh bsp-linux   Run a build
-#   dbuild.sh deploy.sh bsp-linux  Deploy it
+#   dbuild.sh build.sh bsp-so3     Run a build
+#   dbuild.sh deploy.sh bsp-so3    Deploy it
 #   dbuild.sh st.sh -d             Run it under QEMU, graphical
 #
 # The command runs with the project root bind-mounted at its OWN
@@ -54,8 +54,8 @@ pr_usage()
 	printf "                scripts/ and bitbake are on PATH.\n\n"
 	printf "Examples:\n"
 	printf "    %s --build\n" "$progname"
-	printf "    %s build.sh bsp-linux\n" "$progname"
-	printf "    %s deploy.sh bsp-linux\n" "$progname"
+	printf "    %s build.sh bsp-so3\n" "$progname"
+	printf "    %s deploy.sh bsp-so3\n" "$progname"
 	printf "    %s st.sh -d\n" "$progname"
 }
 

--- a/scripts/tezi-feed-serve.sh
+++ b/scripts/tezi-feed-serve.sh
@@ -199,7 +199,13 @@ do_ensure()
 	fi
 
 	running_pid >/dev/null && return 0
-	check_feed || return 0
+
+	# Called after every build and deploy, including on platforms that never
+	# publish a feed (soft/hard storage), so a missing feed is the normal
+	# case here: stay quiet and leave the explaining to check_feed, which
+	# only runs when the server is asked for explicitly.
+
+	[ -d "$feed" ] && [ -f "$feed/image_list.json" ] || return 0
 
 	command -v python3 >/dev/null 2>&1 || {
 		printf "%s: python3 not found — cannot serve the feed\n" "$progname" >&2

--- a/so3/usr/src/ping.c
+++ b/so3/usr/src/ping.c
@@ -1,5 +1,7 @@
 /*
- * Copyright (C) 2020 Julien Quartier <julien.quartier@heig-vd.ch>
+ * Copyright (c) 2020-2026 REDS Institute, HEIG-VD
+ * Author: Julien Quartier <julien.quartier@heig-vd.ch>
+ * Author: Daniel Rossier <daniel.rossier@heig-vd.ch>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 as
@@ -164,10 +166,14 @@ void parse_args(int argc, char **argv)
 int main(int argc, char **argv)
 {
 	int s, i = 0, msg_count = 0, msg_count_succeed = 0, attempt = 0;
+	int len, hlen;
 	unsigned int size = 0;
-	float rtt = 0, rtt_total, rtt_min = 1000000.0, rtt_max = 0.0;
+	float rtt = 0, rtt_total = 0.0, rtt_min = 1000000.0, rtt_max = 0.0;
 	char ip[100];
 	struct ping_pkt packet;
+	char reply[sizeof(struct iphdr) + PING_PKT_LEN];
+	struct iphdr *iph;
+	struct icmphdr *icmph;
 	struct sockaddr_in ping_addr, recv_addr;
 	struct timeval timeout, start, end;
 
@@ -223,7 +229,9 @@ int main(int argc, char **argv)
 
 		size = sizeof(recv_addr);
 
-		if (recvfrom(s, &packet, sizeof(packet), 0, (struct sockaddr *) &recv_addr, &size) <= 0 && msg_count > 1) {
+		len = recvfrom(s, reply, sizeof(reply), 0, (struct sockaddr *) &recv_addr, &size);
+
+		if (len <= 0 && msg_count > 1) {
 			printf("Packet receive failed!!\n");
 			continue;
 		}
@@ -234,10 +242,24 @@ int main(int argc, char **argv)
 
 		rtt = end.tv_usec / 1000.0 + end.tv_sec * 1000 - (start.tv_usec / 1000.0 + start.tv_sec * 1000);
 
-		if (!(packet.hdr.type == 69 && packet.hdr.code == 0)) {
-			printf("Error... Packet received with ICMP type %d code %d\n", packet.hdr.type, packet.hdr.code);
+		/* A raw socket hands over the whole IP datagram, so the ICMP
+		 * message starts after the IP header, whose length is given by
+		 * the IHL field. */
+
+		iph = (struct iphdr *) reply;
+		hlen = iph->ihl * 4;
+
+		if (len < hlen + (int) sizeof(struct icmphdr)) {
+			printf("Error... Truncated reply of %d bytes\n", len);
+			continue;
+		}
+
+		icmph = (struct icmphdr *) (reply + hlen);
+
+		if (!(icmph->type == ICMP_ECHOREPLY && icmph->code == 0)) {
+			printf("Error... Packet received with ICMP type %d code %d\n", icmph->type, icmph->code);
 		} else {
-			printf("%d bytes from %s: icmp_seq=%d ttl=%d time=%f ms\n", PING_PKT_LEN, ip, msg_count, ttl, rtt);
+			printf("%d bytes from %s: icmp_seq=%d ttl=%d time=%f ms\n", len - hlen, ip, msg_count, iph->ttl, rtt);
 
 			rtt_max = fmaxf(rtt_max, rtt);
 			rtt_min = fminf(rtt_min, rtt);
@@ -254,10 +276,6 @@ int main(int argc, char **argv)
 	if (msg_count_succeed > 0)
 		printf("rtt min/avg/max = %f/%f/%f ms\n", rtt_min, rtt_total / msg_count_succeed, rtt_max);
 
+	close(s);
 	return 0;
-
-	/*end:
-
-	 close(s);
-	 return 0;*/
 }


### PR DESCRIPTION
`build.sh bsp-so3` was failing in `usr-so3:do_build`:

```
so3/usr/src/ping.c:39:10: fatal error: lwip/icmp.h: No such file or directory
```

Those lwIP headers are kernel-side (`so3/so3/include/net/lwip/`) and are not
on the user-space include path — nor needed: musl's `<netinet/ip_icmp.h>`
already provides `ICMP_ECHO` / `ICMP_ECHOREPLY` and `struct iphdr`.

Removing the includes alone would have left the reply check broken. The magic
`69` the code compared against was not an ICMP type but `0x45`, the first byte
of the **IP** header (version 4, IHL 5): a raw socket delivers the whole IP
datagram (lwIP calls the raw pcb's receive callback with the payload still on
the IP header, see `net/lwip/core/raw.c:raw_input`), so the ICMP message starts
at `iphdr->ihl * 4`. The reply is now parsed at that offset, the receive buffer
is sized for `iphdr + PING_PKT_LEN` (the old 64-byte one truncated the
payload), a too-short reply is rejected, and the TTL reported is the one that
came back rather than the one requested. `rtt_total` was also summed into
without being initialised, and `close(s)` was commented out under a dead label.

Two build-experience fixes ride along, one commit each:

- the build container's banner, `dbuild.sh`'s header/`--help`, `docker/README.md`,
  the Dockerfile header and the build-system chapter now lead with `bsp-so3`;
  this tree's default target is SO3, `bsp-linux` stays as the alternative;
- `tezi-feed-serve.sh --ensure` runs after every build and deploy, including on
  soft/hard-storage platforms that never publish a TEZI feed, and printed
  "feed directory does not exist yet / run a deploy first" every single time.
  It is silent now when there is nothing to serve; the hint is kept for an
  explicit foreground invocation.

## Testing

- `build.sh bsp-so3` and `deploy.sh bsp-so3` on virt64, clean.
- Booted under QEMU (`st.sh`) to the SO3 shell; `ping.elf` present in the rootfs.
- `clang-format --dry-run -Werror so3/usr/src/ping.c` clean.

Note: `ping` cannot be exercised on virt32/virt64 as shipped — `CONFIG_NET` is
off in every defconfig and the only NIC driver is `smc911x`, which QEMU's
`virt` machine does not provide (`doc/source/lwip.rst` already documents this).
The fix is therefore verified by build and inspection, not by a live echo reply.