### PR TITLE
usr: say what actually went wrong in ping

### DIFF
--- a/so3/usr/src/ping.c
+++ b/so3/usr/src/ping.c
@@ -21,6 +21,7 @@
 /* ping: send ICMP echo requests to a host and report the replies, including
  * the round-trip times. */
 
+#include <errno.h>
 #include <string.h>
 #include <unistd.h>
 #include <syscall.h>
@@ -233,7 +234,7 @@ int main(int argc, char **argv)
 	s = socket(AF_INET, SOCK_RAW, IPPROTO_ICMP);
 
 	if (s < 0) {
-		printf("Impossible to obtain a socket file descriptor!!\n");
+		printf("Cannot open the ICMP socket: %s\n", strerror(errno));
 		return 1;
 	}
 
@@ -265,7 +266,7 @@ int main(int argc, char **argv)
 		gettimeofday(&start, NULL);
 
 		if (sendto(s, &packet, sizeof(packet), 0, (struct sockaddr *) &ping_addr, sizeof(ping_addr)) <= 0) {
-			printf("Packet sending failed!!\n");
+			printf("Cannot send icmp_seq=%d: %s\n", msg_count, strerror(errno));
 			continue;
 		}
 
@@ -273,10 +274,16 @@ int main(int argc, char **argv)
 
 		len = recvfrom(s, reply, sizeof(reply), 0, (struct sockaddr *) &recv_addr, &size);
 
-		/* A timeout (SO_RCVTIMEO) lands here too, which is the normal
-		 * outcome for a host that never answers. */
+		/* A host that never answers is the normal case, not a failure:
+		 * SO_RCVTIMEO expires and lwIP reports it as EWOULDBLOCK (EAGAIN,
+		 * the same value in musl). Anything else is a real error and says
+		 * which one. */
 		if (len <= 0) {
-			printf("Packet receive failed!!\n");
+			if ((len < 0) && (errno != EAGAIN))
+				printf("Cannot receive icmp_seq=%d: %s\n", msg_count, strerror(errno));
+			else
+				printf("Request timeout for icmp_seq=%d\n", msg_count);
+
 			continue;
 		}
 


### PR DESCRIPTION
`Packet receive failed!!` was printed for the ordinary case — a host that simply
does not answer — and said nothing about the rare case where something really
did go wrong. `Packet sending failed!!` had the same problem: it hid a plain
`No route to host` when `ping` ran before DHCP had brought the interface up
(which is exactly what a `ping` typed at the prompt right after boot does), and
the socket error hid `Function not implemented` on a build with `CONFIG_NET`
off.

A receive timeout — `SO_RCVTIMEO`, which lwIP maps to `EWOULDBLOCK` — now prints
the usual `Request timeout for icmp_seq=N`. Anything else prints
`strerror(errno)`, as do the send and socket paths.

Before:

```
/ % ping 192.168.1.1
Packet sending failed!!
Packet sending failed!!
IP Network up and running with address 10.0.2.15
```

After, on virt64 (`build.sh bsp-so3` + `deploy.sh bsp-so3`, booted with `st.sh`):

```
/ % ping -c 3 10.0.2.1
Request timeout for icmp_seq=1
Request timeout for icmp_seq=2
Request timeout for icmp_seq=3

--- 10.0.2.1 ping statistics ---
3 packets transmitted, 0 received, 100.000000% packet loss
```

A reachable host is unaffected (`ping -c 2 10.0.2.2`, 0% loss).
`scripts/check-format.sh` is clean.