### PR TITLE
build: teach updiff U-Boot's generated files

### DIFF
--- a/build/meta/classes/patch.bbclass
+++ b/build/meta/classes/patch.bbclass
@@ -299,6 +299,12 @@ python patch_do_diffcompose() {
         # `make savedefconfig` writes this at the tree root; it is an
         # output, never a source.
         'defconfig',
+        # U-Boot's own generated files: the boot logo turned into assembly
+        # and headers, the EFI hello-world stub, the config header kbuild
+        # writes, and the defconfig 'make savedefconfig' leaves behind
+        # under its U-Boot spelling.
+        'u_boot_logo.S', 'bmp_logo.h', 'bmp_logo_data.h',
+        'helloworld_efi.S', 'config.h', 'generated_defconfig',
         # lex / yacc / bison generated parsers — kconfig, dtc, and any other
         # consumer of flex/bison. Sources are *.l / *.y (kept); outputs are
         # *.lex.c, *.tab.c, *.tab.h (excluded).


### PR DESCRIPTION
The last two rounds of this list came from kernels; these come from U-Boot,
and they landed in a patch series the same way: the tree was built in
`IB_TARGET` before `updiff` ran.

The boot logo turned into assembly and into headers, the EFI hello-world
stub, the config header kbuild writes, and the defconfig `make
savedefconfig` leaves behind under U-Boot's own spelling. Each is rewritten
by its generator on the next build, so a patch for one is redundant at best
and applies stale content over the generator's output at worst.

Found while bumping the OpenCN tree to U-Boot 2024.07: six of them went
into the series before I caught them.