### PR TITLE
usr: keep symbolic links when copying the user space into ${S}

### DIFF
--- a/build/meta-usr/classes/usr.bbclass
+++ b/build/meta-usr/classes/usr.bbclass
@@ -48,7 +48,12 @@ def __retrieve_usr_dir(d):
     # so that it will be possible to handle the fetch of submodules before
     # the execution of attach_infrabase task
 
-    cmd = f"find . -not -path '*/.git/*' -and -not -path '*/patches/*' -and \( -type f -or -type d -empty \) -exec cp -r --parents -t {dst_dir} {{}} +"
+    # -type l matters: without it symbolic links are simply not seen, and
+    # the round-trip through ${S} drops every one of them -- the build then
+    # fails at cmake time on a missing source rather than anywhere
+    # informative. cp -a instead of -r to copy links as links.
+
+    cmd = f"find . -not -path '*/.git/*' -and -not -path '*/patches/*' -and \( -type f -or -type l -or -type d -empty \) -exec cp -a --parents -t {dst_dir} {{}} +"
     result = subprocess.run(cmd, shell=True, check=True, cwd=src_dir)
 
 python retrieve_usr_dir() {


### PR DESCRIPTION
`retrieve_usr_dir` enumerated the tree with

```
find . ... \( -type f -or -type d -empty \)
```

A symbolic link is neither a regular file nor an empty directory, so every
link in the user space was dropped on the way through `${S}` and never
reached `IB_TARGET`.

It fails late and unhelpfully: cmake stops on a missing source file, with
nothing naming the link that went missing. In the OpenCN tree five links are
involved, two of them pointing into the kernel tree
(`target/ethercat_tool/soe_errors.c`, `common/include/opencn`), and the build
dies on `Cannot find source file: soe_errors.c`.

`find` gains `-type l`, and the copy becomes `cp -a` so links are copied as
links rather than followed.

Same blind spot `do_diffcompose` has for symlinks, which `IB_SYMLINK` works
around on the patch side; here it can simply be fixed.

Surfaced while converting OpenCN's four git submodules under `linux/usr` into
fetched components, which let `do_attach_infrabase` be re-enabled on that
recipe — and immediately showed this.